### PR TITLE
Update app url support to change from using parameters to using params a...

### DIFF
--- a/controllers/History.js
+++ b/controllers/History.js
@@ -23,6 +23,29 @@ function(lang, declare, on, Controller){
 
 			this.bind(window, "popstate", lang.hitch(this, this.onPopState));
 		},
+		
+		_buildHashWithParams: function(hash, params){
+			// summary:
+			//		build up the url hash adding the params
+			// hash: String
+			//		the url hash
+			// params: Object
+			//		the params object
+			//
+			// returns:
+	 		//		the params object
+			//
+			if(hash.charAt(0) !== "#"){
+				hash = "#"+hash;
+			}
+			for(var item in params){
+				var value = params[item];
+				if(item && value != null){
+					hash = hash+"&"+item+"="+params[item];
+				}
+			}
+			return hash; // String			
+		},
 
 		onStartTransition: function(evt){
 			// summary:
@@ -33,7 +56,8 @@ function(lang, declare, on, Controller){
 			//		|	var transOpts = {
 			//		|		title:"List",
 			//		|		target:"items,list",
-			//		|		url: "#items,list"
+			//		|		url: "#items,list",
+			//		|		params: {"param1":"p1value"}
 			//		|	};
 			//		|	new TransitionEvent(domNode, transOpts, e).dispatch();
 			//
@@ -47,9 +71,15 @@ function(lang, declare, on, Controller){
 			if(!target && regex.test(evt.detail.href)){
 				target = evt.detail.href.match(regex)[1];
 			}
+			
+			// create url hash from target if it is not set
+			var hash = evt.detail.url || "#"+evt.detail.target;
+			if(evt.detail.params){
+				hash = this._buildHashWithParams(hash, evt.detail.params);
+			}
 
 			// push states to history list
-			history.pushState(evt.detail,evt.detail.href, evt.detail.url);
+			history.pushState(evt.detail,evt.detail.href, hash);
 		},
 
 		onPopState: function(evt){
@@ -70,8 +100,9 @@ function(lang, declare, on, Controller){
 			if(!state){
 				if(!this.app._startView && window.location.hash){
 					state = {
-						target: (location.hash && location.hash.charAt(0) == "#") ? location.hash.substr(1) : location.hash,
-						url: location.hash
+						target: ((location.hash && location.hash.charAt(0) == "#") ? location.hash.substr(1) : location.hash).split('&')[0],
+						url: location.hash,
+						params: this.app.getParamsFromHash(location.hash) || this.defaultParams || {}
 					}
 				}else{
 					state = {};
@@ -79,6 +110,7 @@ function(lang, declare, on, Controller){
 			}
 
 			var target = state.target || this.app._startView || this.app.defaultView;
+			var params = state.params || this.app._startParams || this.app.defaultParams || {};
 
 			if(this.app._startView){
 				this.app._startView = null;
@@ -94,7 +126,7 @@ function(lang, declare, on, Controller){
 			// transition to the target view
 			this.app.trigger("transition", {
 				"viewId": target,
-				"opts": lang.mixin({reverse: false}, evt.detail)
+				"opts": lang.mixin({reverse: false}, evt.detail, {"params": params})
 			});
 		}
 	});

--- a/controllers/Load.js
+++ b/controllers/Load.js
@@ -42,9 +42,9 @@ function(lang, declare, on, Deferred, when, Controller, View){
 			var parts = viewId.split(',');
 			var childId = parts.shift();
 			var subIds = parts.join(",");
-			var parameters = event.parameters || "";
+			var params = event.params || "";
 			
-			var def = this.loadChild(parent, childId, subIds, parameters);
+			var def = this.loadChild(parent, childId, subIds, params);
 			// call Load event callback
 			if(event.callback){
 				when(def, event.callback);
@@ -52,7 +52,7 @@ function(lang, declare, on, Deferred, when, Controller, View){
 			return def;
 		},
 
-		createChild: function(parent, childId, subIds, parameters){
+		createChild: function(parent, childId, subIds, params){
 			// summary:
 			//		Create dojox.app.view instance if it is not loaded.
 			//
@@ -76,12 +76,12 @@ function(lang, declare, on, Deferred, when, Controller, View){
 				"id": id,
 				"name": childId,
 				"parent": parent
-			},{"parameters": parameters}));
+			},{"params": params}));
 			parent.children[id] = newView;
 			return newView.start();
 		},
 
-		loadChild: function(parent, childId, subIds, parameters){
+		loadChild: function(parent, childId, subIds, params){
 			// summary:
 			//		Load child and sub children views recursively.
 			//
@@ -91,6 +91,8 @@ function(lang, declare, on, Deferred, when, Controller, View){
 			//		view id need to be loaded.
 			// subIds: String
 			//		sub views' id of this view.
+			// params: Object
+			//		params of this view.
 			// returns:
 			//		A dojo.Deferred instance which will be resovled when all views loaded.
 
@@ -107,7 +109,7 @@ function(lang, declare, on, Deferred, when, Controller, View){
 			var loadChildDeferred = new Deferred();
 			var createPromise;
 			try{
-				createPromise = this.createChild(parent, childId, subIds, parameters);
+				createPromise = this.createChild(parent, childId, subIds, params);
 			}catch(ex){
 				loadChildDeferred.reject("load child '"+childId+"' error.");
 				return loadChildDeferred.promise;
@@ -122,7 +124,7 @@ function(lang, declare, on, Deferred, when, Controller, View){
 				childId = parts.shift();
 				subIds = parts.join(',');
 				if(childId){
-					var subLoadDeferred = this.loadChild(child, childId, subIds, parameters);
+					var subLoadDeferred = this.loadChild(child, childId, subIds, params);
 					when(subLoadDeferred, function(){
 						loadChildDeferred.resolve();
 					},

--- a/main.js
+++ b/main.js
@@ -115,7 +115,7 @@ function(kernel, require, lang, declare, Deferred, when, has, config, on, ready,
 			// event: String
 			//		event name. The event is binded by controller.bind() method.
 			// params: Object
-			//		event parameters.
+			//		event params.
 			on.emit(this.domNode, event, params);
 		},
 
@@ -167,26 +167,26 @@ function(kernel, require, lang, declare, Deferred, when, has, config, on, ready,
 			}
 		},
 
-		_getParameters: function(hash){
+		getParamsFromHash: function(hash){
 			// summary:
-			//		get the parameters from the hash
+			//		get the params from the hash
 			//
 			// hash: String
 			//		the url hash
 			//
 			// returns:
-			//		the parameters object
+			//		the params object
 			//
-			var parameters = {};
+			var params = {};
 			if(hash && hash.length){
 				for(var parts= hash.split("&"), x= 0; x<parts.length; x++){
 					var tp = parts[x].split("="), name=tp[0], value=encodeURIComponent(tp[1]||""); 
 					if(name && value) {
-						parameters[name] = value;
+						params[name] = value;
 					}
 				}
 			}
-			return parameters; // Object
+			return params; // Object
 		},
 
 		setupControllers: function(){
@@ -198,7 +198,7 @@ function(kernel, require, lang, declare, Deferred, when, has, config, on, ready,
 			// move set _startView operation from history module to application
 			var hash = window.location.hash;
 			this._startView = (((hash && hash.charAt(0) == "#") ? hash.substr(1) : hash) || this.defaultView).split('&')[0];
-			this._startParameters = this._getParameters(hash) || this.defaultParameters || {};
+			this._startParams = this.getParamsFromHash(hash) || this.defaultParams || {};
 		},
 
 		startup: function(){
@@ -209,7 +209,7 @@ function(kernel, require, lang, declare, Deferred, when, has, config, on, ready,
 				
 				this.trigger("load", {
 					"viewId": this.defaultView,
-					"parameters": this._startParameters,
+					"params": this._startParams,
 					"callback": lang.hitch(this, function(){
 						var selectId = this.defaultView.split(",");
 						selectId = selectId.shift();
@@ -217,13 +217,14 @@ function(kernel, require, lang, declare, Deferred, when, has, config, on, ready,
 						// transition to startView. If startView==defaultView, that means initial the default view.
 						this.trigger("transition", {
 							"viewId": this._startView,
-							"parameters": this._startParameters
+							"params": this._startParams
 						});
 						this.setStatus(this.lifecycle.STARTED);
 					})
 				});
 			}));
-		}
+		}		
+		
 	});
 
 	function generateApp(config, node, appSchema, validate){

--- a/tests/modelApp/config.json
+++ b/tests/modelApp/config.json
@@ -50,13 +50,6 @@
 	//models and instantiation parameters for the models. Including 'type' as a property allows
 	//one to overide the class that will be used for the model.  By default it is dojox/mvc/model
 	"models": {
-	   "names": {
-					"modelLoader": "dojox/app/utils/mvcModel",
-					"type": "dojox/mvc/EditStoreRefListController",
-					"params":{
-		     		 	"store": {"$ref":"#stores.namesStore"}
-		  		 	}	       
-	   },
        "repeatmodels": {
     				"modelLoader": "dojox/app/utils/mvcModel",
 					"type": "dojox/mvc/EditStoreRefListController",
@@ -81,6 +74,15 @@
 		},
 
 		"simple":{
+            "models": {
+				"names": {
+					"modelLoader": "dojox/app/utils/mvcModel",
+					"type": "dojox/mvc/EditStoreRefListController",
+					"params":{
+		     		 	"store": {"$ref":"#stores.namesStore"}
+		  		 	}	       
+	   			}
+            },
 			"definition" : "./views/simple.js",
 			"template": "./templates/simple.html",
 			"dependencies":["dojox/mobile/TextBox"]

--- a/tests/modelApp/index.html
+++ b/tests/modelApp/index.html
@@ -44,6 +44,7 @@
 					"loader-defineModule":1
 				},
 				async:1,
+				mvc: {debugBindings: 1},
 				app: {debugApp: 1}  // set debugApp to log app transtions and view activate/deactivate 
 			}
 		</script>

--- a/tests/modelApp/views/repeat.js
+++ b/tests/modelApp/views/repeat.js
@@ -21,7 +21,8 @@ function(dom, connect, registry, at, TransitionEvent, Repeat, getStateful, Outpu
 		var transOpts = {
 			title : "repeatDetails",
 			target : "repeatDetails",
-			url : "#repeatDetails&cursor=" + index
+			//url : "#repeatDetails", // this is optional if not set it will be created from target   
+			params : {"cursor":index}
 		};
 		var e = window.event;
 		new TransitionEvent(e.srcElement, transOpts, e).dispatch(); 

--- a/tests/modelApp/views/repeatDetails.js
+++ b/tests/modelApp/views/repeatDetails.js
@@ -6,8 +6,9 @@ function(dom, connect, registry, at, getStateful, Output){
 
 	// show an item detail
 	var setDetailsContext = function(index){
-		if(parseInt(index) < repeatmodel.model.length){
-			repeatmodel.set("cursorIndex", index);
+		// only set the cursor if it is different and valid
+		if(parseInt(index) != repeatmodel.cursorIndex && parseInt(index) < repeatmodel.model.length){
+			repeatmodel.set("cursorIndex", parseInt(index));
 		}
 	};
 
@@ -25,27 +26,15 @@ function(dom, connect, registry, at, getStateful, Output){
 		// repeate view init
 		init: function(){
 			repeatmodel = this.loadedModels.repeatmodels;
-
-			// if this.parameters["cursor"] is set use it to set the selected Details Context
-			if(this.parameters["cursor"]){
-				setDetailsContext(this.parameters["cursor"]);
-			}
-
-			var repeatDom = dom.byId('repeatWidget');
-			var connectResult;
-			connectResult = connect.connect(repeatDom, "button[id^=\"detail\"]:click", function(e){
-				var index = getIndexFromId(e.target.id, "detail");
-				setDetailsContext(index);
-			});
-			_connectResults.push(connectResult);
 		},
 
-		// repeate view destroy
-		destroy: function(){
-			var connectResult = _connectResults.pop();
-			while(connectResult){
-				connect.disconnect(connectResult);
-				connectResult = _connectResults.pop();
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			// if this.params["cursor"] is set use it to set the selected Details Context
+			if(this.params["cursor"]){
+				setDetailsContext(this.params["cursor"]);
 			}
 		}
 	}


### PR DESCRIPTION
...nd take a params object separate from the url, and buildup the url with the params.  Also build the url hash from the target if it is not passed.

So with this update the transitionOptions can have an optional params object with the params which we will build into the url, and if the url is not passed it will be created from the target.

``` javascript
        var transOpts = {
            title : "repeatDetails",
            target : "repeatDetails",
            //url : "#repeatDetails", // this is optional if not set it will be created from target   
            params : {"cursor":index}
        };
        var e = window.event;
        new TransitionEvent(e.srcElement, transOpts, e).dispatch(); 
```
