### PR TITLE
use MID is store type instead of class names.  See #44.

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,12 +40,13 @@ function(kernel, require, lang, declare, Deferred, when, has, config, on, ready,
 				//create stores in the configuration.
 				for(var item in params.stores){
 					if(item.charAt(0) !== "_"){//skip the private properties
-						var type = params.stores[item].type ? params.stores[item].type : "dojo.store.Memory";
+						var type = params.stores[item].type ? params.stores[item].type : "dojo/store/Memory";
 						var config = {};
 						if(params.stores[item].params){
 							lang.mixin(config, params.stores[item].params);
 						}
-						var storeCtor = lang.getObject(type);
+						// we assume the store is here through dependencies
+						var storeCtor = require(type);
 						if(config.data && lang.isString(config.data)){
 							//get the object specified by string value of data property
 							//cannot assign object literal or reference to data property

--- a/tests/layoutApp/config.json
+++ b/tests/layoutApp/config.json
@@ -29,13 +29,13 @@
 	//stores we are using 
 	"stores": {
 	   "namesStore":{
-	       "type": "dojo.store.Memory",
+	       "type": "dojo/store/Memory",
 		   "params": {
 		      "data": "modelApp.names"
 		   }
 	   },
        "repeatStore":{
-           "type": "dojo.store.Memory",
+           "type": "dojo/store/Memory",
            "params": {
                 "data": "modelApp.repeatData"
            }

--- a/tests/modelApp/config.json
+++ b/tests/modelApp/config.json
@@ -34,13 +34,13 @@
 	//stores we are using 
 	"stores": {
 	   "namesStore":{
-	       "type": "dojo.store.Memory",
+	       "type": "dojo/store/Memory",
 		   "params": {
 		      "data": "modelApp.names"
 		   }
 	   },
        "repeatStore":{
-           "type": "dojo.store.Memory",
+           "type": "dojo/store/Memory",
            "params": {
                 "data": "modelApp.repeatData"
            }

--- a/tests/simpleModelApp/config.json
+++ b/tests/simpleModelApp/config.json
@@ -34,19 +34,19 @@
 	//stores we are using 
 	"stores": {
 	   "namesStore":{
-	       "type": "dojo.store.Memory",
+	       "type": "dojo/store/Memory",
 		   "params": {
 		      "data": "modelApp.names"
 		   }
 	   },
        "repeatStore":{
-           "type": "dojo.store.Memory",
+           "type": "dojo/store/Memory",
            "params": {
                 "data": "modelApp.repeatData"
            }
        },
 	   "repeatItemStore":{
-	       "type": "dojo.data.ItemFileWriteStore",
+	       "type": "dojo/data/ItemFileWriteStore",
 		   "params": {
 				"url": "./resources/data/repeat.json"
 		   }


### PR DESCRIPTION
On the contrary of model loading I'm assuming the module that is referred for the store type is loaded from the app/view dependencies. I think this is ok because this was anyway already the case when MID where not used.
Maybe this simplification could also be done for module loading.
