### PR TITLE
Allow config option to prevent automatic load of Load, Transition and Layout controllers, to allow them to be replaced by the app.

### DIFF
--- a/main.js
+++ b/main.js
@@ -194,9 +194,11 @@ function(kernel, require, lang, declare, Deferred, when, has, config, on, ready,
 
 		setupControllers: function(){
 			// create application controller instance
-			this.controllers.push(new LoadController(this));
-			this.controllers.push(new TransitionController(this));
-			this.controllers.push(new LayoutController(this));
+			if(!this.noAutoLoadControllers){
+				this.controllers.push(new LoadController(this));
+				this.controllers.push(new TransitionController(this));
+				this.controllers.push(new LayoutController(this));
+			}
 
 			// move set _startView operation from history module to application
 			var hash = window.location.hash;

--- a/tests/modelApp/config.json
+++ b/tests/modelApp/config.json
@@ -27,6 +27,12 @@
 		//"dojox/app/module/lifecycle"
 	],
 	
+	// If noAutoLoadControllers is set to true a Load, Transition, and Layout controller 
+	// should be included in the list of controllers.  
+	// If noAutoLoadControllers is set to false (or not set) the default Load, Transition, and Layout  
+	// controllers will be added automatically.  
+	"noAutoLoadControllers" : false,  
+
 	"controllers": [
 		"dojox/app/controllers/History"
 	],

--- a/tests/simpleModelApp/config.json
+++ b/tests/simpleModelApp/config.json
@@ -27,7 +27,16 @@
 	// by creating and including one or more of these
 	"modules": [],
 	
+	// If noAutoLoadControllers is set to true a Load, Transition, and Layout controller 
+	// should be included in the list of controllers.  
+	// If noAutoLoadControllers is set to false (or not set) the default Load, Transition, and Layout  
+	// controllers will be added automatically.  
+	"noAutoLoadControllers" : true,  
+	
 	"controllers": [
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/controllers/Layout",
 		"dojox/app/controllers/History"
 	],
 


### PR DESCRIPTION
This is a fix for issue #76.
