### PR TITLE
Update noMenuBar fix, and a few other updates listed below.

### DIFF
--- a/controllers/Layout.js
+++ b/controllers/Layout.js
@@ -138,7 +138,7 @@ function(lang, declare, has, on, win, array, config, topic, query, domStyle, dom
 
 			// Compute and save the size of my border box and content box
 			// (w/out calling dojo/_base/html.contentBox() since that may fail if size was recently set)
-			if(view == this.app){
+			if(view !== this.app){
 				var cs = domStyle.getComputedStyle(node);
 				var me = domGeom.getMarginExtents(node, cs);
 				var be = domGeom.getBorderExtents(node, cs);

--- a/tests/scrollableTestApp/index.html
+++ b/tests/scrollableTestApp/index.html
@@ -25,9 +25,9 @@
    					data-dojo-config="mblThemeFiles:['@theme',['dojox/app/tests/scrollableTestApp','todo']]"></script>
 
 		<script type="text/javascript" src="../../../../dojo/dojo.js" data-dojo-config="parseOnLoad: false,
-				mblHideAddressBar: false,
+				mblHideAddressBar: true,
 				mblAndroidWorkaround: false,
-				mblAlwaysHideAddressBar: false,
+				mblAlwaysHideAddressBar: true,
 				app: {debugApp: 1},  // set debugApp to log app transtions and view activate/deactivate
 				mvc: {debugBindings: 0},  // set on to debug mvc data bindings
 				async: 1">

--- a/tests/simpleModelApp/config.json
+++ b/tests/simpleModelApp/config.json
@@ -22,6 +22,7 @@
 		"dojox/app/utils/simpleModel",
 		"dojox/app/utils/mvcModel",
 		"dojox/mvc/EditStoreRefListController",
+		"dojox/mvc/EditModelRefController",
 		"dojox/mobile/deviceTheme"
 	],
 	// Modules for the application.  The are basically used as the second

--- a/widgets/_ScrollableMixin.js
+++ b/widgets/_ScrollableMixin.js
@@ -28,7 +28,7 @@ define([
 		allowNestedScrolls: true,
 
 		constructor: function(){
-			this.scrollableParams = {};
+			this.scrollableParams = {noResize: true}; // set noResize to true to match the way it was done in app/widgets/scrollable.js
 		},
 
 		destroy: function(){


### PR DESCRIPTION
Update noMenuBar fix and change the scrollableTestApp to hide the menubar, fix a config problem with the simpleModelApp test, and tweak the _ScrollableMixin to set noResize to true so that it will work like it used to work when app had its own copy of scrollable.js .
