### PR TITLE
For dojo18 branch Add noMenuBar fix and change the scrollableTestApp to ...

### DIFF
--- a/controllers/Layout.js
+++ b/controllers/Layout.js
@@ -1,6 +1,6 @@
-define(["dojo/_base/lang", "dojo/_base/declare", "dojo/sniff", "dojo/on", "dojo/_base/window", "dojo/_base/array",
-	"dojo/query", "dojo/dom-style", "dojo/dom-attr", "dojo/dom-geometry", "dijit/registry", "../Controller", "../layout/utils"],
-function(lang, declare, has, on, win, array, query, domStyle, domAttr, domGeom, registry, Controller, layoutUtils){
+define(["dojo/_base/lang", "dojo/_base/declare", "dojo/sniff", "dojo/on", "dojo/_base/window", "dojo/_base/array", "dojo/_base/config",
+	"dojo/topic", "dojo/query", "dojo/dom-style", "dojo/dom-attr", "dojo/dom-geometry", "dijit/registry", "../Controller", "../layout/utils"],
+function(lang, declare, has, on, win, array, config, topic, query, domStyle, domAttr, domGeom, registry, Controller, layoutUtils){
 	// module:
 	//		dojox/app/controllers/Layout
 	// summary:
@@ -22,8 +22,14 @@ function(lang, declare, has, on, win, array, query, domStyle, domAttr, domGeom, 
 			};
 			this.inherited(arguments);
 
-			// bind to browsers orientationchange event for ios otherwise bind to browsers resize
-			this.bind(win.global, has("ios") ? "orientationchange" : "resize", lang.hitch(this, this.onResize));
+			// if we are using dojo mobile & we are hiding adress bar we need to be bit smarter and listen to
+			// dojo mobile events instead
+			if(config.mblHideAddressBar){
+				topic.subscribe("/dojox/mobile/afterResizeAll", lang.hitch(this, this.onResize));
+			}else{
+				// bind to browsers orientationchange event for ios otherwise bind to browsers resize
+				this.bind(win.global, has("ios") ? "orientationchange" : "resize", lang.hitch(this, this.onResize));
+			}
 		},
 
 		onResize: function(){
@@ -112,7 +118,6 @@ function(lang, declare, has, on, win, array, query, domStyle, domAttr, domGeom, 
 			//
 			// view: Object
 			//		view instance needs to do layout.
-
 			var node = view.domNode;
 			// set margin box size, unless it wasn't specified, in which case use current size
 			if(changeSize){
@@ -133,20 +138,31 @@ function(lang, declare, has, on, win, array, query, domStyle, domAttr, domGeom, 
 
 			// Compute and save the size of my border box and content box
 			// (w/out calling dojo/_base/html.contentBox() since that may fail if size was recently set)
-			var cs = domStyle.getComputedStyle(node);
-			var me = domGeom.getMarginExtents(node, cs);
-			var be = domGeom.getBorderExtents(node, cs);
-			var bb = (view._borderBox = {
-				w: mb.w - (me.w + be.w),
-				h: mb.h - (me.h + be.h)
-			});
-			var pe = domGeom.getPadExtents(node, cs);
-			view._contentBox = {
-				l: domStyle.toPixelValue(node, cs.paddingLeft),
-				t: domStyle.toPixelValue(node, cs.paddingTop),
-				w: bb.w - pe.w,
-				h: bb.h - pe.h
-			};
+			if(view !== this.app){
+				var cs = domStyle.getComputedStyle(node);
+				var me = domGeom.getMarginExtents(node, cs);
+				var be = domGeom.getBorderExtents(node, cs);
+				var bb = (view._borderBox = {
+					w: mb.w - (me.w + be.w),
+					h: mb.h - (me.h + be.h)
+				});
+				var pe = domGeom.getPadExtents(node, cs);
+				view._contentBox = {
+					l: domStyle.toPixelValue(node, cs.paddingLeft),
+					t: domStyle.toPixelValue(node, cs.paddingTop),
+					w: bb.w - pe.w,
+					h: bb.h - pe.h
+				};
+			}else{
+				// if we are layouting the top level app the above code does not work when hiding address bar
+				// so let's use similar code to dojo mobile.
+				view._contentBox = {
+					l: 0,
+					t: 0,
+					h: win.global.innerHeight || win.doc.documentElement.clientHeight,
+					w: win.global.innerWidth || win.doc.documentElement.clientWidth
+				};
+			}
 
 			this._doLayout(view);
 

--- a/tests/scrollableTestApp/index.html
+++ b/tests/scrollableTestApp/index.html
@@ -25,9 +25,9 @@
    					data-dojo-config="mblThemeFiles:['@theme',['dojox/app/tests/scrollableTestApp','todo']]"></script>
 
 		<script type="text/javascript" src="../../../../dojo/dojo.js" data-dojo-config="parseOnLoad: false,
-				mblHideAddressBar: false,
+				mblHideAddressBar: true,
 				mblAndroidWorkaround: false,
-				mblAlwaysHideAddressBar: false,
+				mblAlwaysHideAddressBar: true,
 				app: {debugApp: 1},  // set debugApp to log app transtions and view activate/deactivate
 				mvc: {debugBindings: 0},  // set on to debug mvc data bindings
 				async: 1">

--- a/widgets/_ScrollableMixin.js
+++ b/widgets/_ScrollableMixin.js
@@ -28,7 +28,7 @@ define([
 		allowNestedScrolls: true,
 
 		constructor: function(){
-			this.scrollableParams = {};
+			this.scrollableParams = {noResize: true}; // set noResize to true to match the way it was done in app/widgets/scrollable.js
 		},
 
 		destroy: function(){


### PR DESCRIPTION
...hide the menubar, and tweak the _ScrollableMixin to set noResize to true so that it will work like it used to work when app had its own copy of scrollable.js .
