### PR TITLE
Globalization implementation 

### DIFF
--- a/View.js
+++ b/View.js
@@ -1,33 +1,32 @@
 define(["require", "dojo/when", "dojo/on", "dojo/_base/declare", "dojo/_base/lang", "dojo/Deferred",
 		"dijit/Destroyable", "dijit/_TemplatedMixin", "dijit/_WidgetsInTemplateMixin", "./ViewBase"],
 	function(require, when, on, declare, lang, Deferred, Destroyable, _TemplatedMixin, _WidgetsInTemplateMixin, ViewBase){
-	// module:
-	//		dojox/app/View
-	// summary:
-	//		dojox/app view object, each view can have one parent view and several children views.
 
 	return declare("dojox.app.View", [_TemplatedMixin, _WidgetsInTemplateMixin, Destroyable, ViewBase], {
+		// summary:
+		//		View class inheriting from ViewBase adding templating & globalization capabilities.
 		constructor: function(params){
 			// summary:
-			//		init view object. A user can use configuration file or programing type to create a view instance.
+			//		Constructs a View instance either from a configuration or programmatically.
 			//
 			// example:
 			//		|	use configuration file
 			//		|
 			// 		|	// load view definition from views/simple.js by default
 			//		|	"simple":{
-			//		|		"template": "./templates/simple.html",
+			//		|		"template": "myapp/templates/simple.html",
+			//		|		"nls": "myapp/nls/simple"
 			//		|		"dependencies":["dojox/mobile/TextBox"]
 			//		|	}
 			//		|
 			//		|	"home":{
-			//		|		"template": "./templates/home.html",
+			//		|		"template": "myapp/templates/home.html",
 			//		|		"definition": "none",	// identify no view definition
 			//		|		"dependencies":["dojox/mobile/TextBox"]
 			//		|	}
 			//		|	"main":{
-			//		|		"template": "./templates/main.html",
-			//		|		"definition": "./views/main.js", // identify load view definition from views/main.js
+			//		|		"template": "myapp/templates/main.html",
+			//		|		"definition": "myapp/views/main.js", // identify load view definition from views/main.js
 			//		|		"dependencies":["dojox/mobile/TextBox"]
 			//		|	}
 			//
@@ -48,11 +47,12 @@ define(["require", "dojo/when", "dojo/on", "dojo/_base/declare", "dojo/_base/lan
 			//		- app: the app
 			//		- id: view id
 			//		- name: view name
-			//		- template: view template url. If templateString not empty, ignore this parameter.
+			//		- template: view template identifier. If templateString is not empty, this parameter is ignored.
 			//		- templateString: view template string
-			//		- definition: view definition url
+			//		- definition: view definition module identifier
 			//		- parent: parent view
 			//		- children: children views
+			//		- nls: nls definition module identifier
 		},
 
 		// _TemplatedMixin requires a connect method if data-dojo-attach-* are used
@@ -60,7 +60,7 @@ define(["require", "dojo/when", "dojo/on", "dojo/_base/declare", "dojo/_base/lan
 			return this.own(on(obj, event, lang.hitch(this, method)))[0];  // handle
 		},
 
-		_loadViewTemplate: function(){
+		_loadTemplate: function(){
 			// summary:
 			//		load view HTML template and dependencies.
 			// tags:
@@ -111,15 +111,66 @@ define(["require", "dojo/when", "dojo/on", "dojo/_base/declare", "dojo/_base/lan
 			}
 		},
 
+		_loadNls: function(){
+			// summary:
+			//		load view nls file.
+			// tags:
+			//		private
+			//
+			if(this.nls){
+				var nlsDef = new Deferred();
+				var path = this.nls;
+				var requireSignal;
+				try{
+					var loadFile = path;
+					var index = loadFile.indexOf("./");
+					if(index >= 0){
+						loadFile = path.substring(index+2);
+					}
+					requireSignal = require.on("error", function(error){
+						if (nlsDef.isResolved() || nlsDef.isRejected()) {
+							return;
+						}
+						if(error.info[0] && (error.info[0].indexOf(loadFile)>= 0)){
+							nlsDef.resolve(false);
+							requireSignal.remove();
+						}
+					});
+
+					if(path.indexOf("./") == 0){
+						path = "app/"+path;
+					}
+
+					require(["dojo/i18n!"+path], function(nls){
+						nlsDef.resolve(nls);
+						requireSignal.remove();
+					});
+				}catch(e){
+					nlsDef.reject(e);
+					requireSignal.remove();
+				}
+				return nlsDef;
+			}
+			return true;
+		},
+
 		// start view
 		load: function(){
 			var tplDef = new Deferred();
 			var defDef = this.inherited(arguments);
+			var nlsDef = this._loadNls();
 			// when parent loading is done (definition), proceed with template
 			// (for data-dojo-* to work we need to wait for definition to be here, this is also
 			// useful when the definition is used as a layer for the view)
 			when(defDef, lang.hitch(this, function(){
-				when(this._loadViewTemplate(), function(value){
+				when(nlsDef, lang.hitch(this, function(nls){
+					if(nls){
+						// make sure template can access nls doing ${nls.myprop}
+						this.nls = {};
+						lang.mixin(this.nls, nls);
+					}
+				}));
+				when(this._loadTemplate(), function(value){
 					tplDef.resolve(value);
 				});
 			}));

--- a/ViewBase.js
+++ b/ViewBase.js
@@ -2,9 +2,11 @@ define(["require", "dojo/when", "dojo/on", "dojo/dom-attr", "dojo/_base/declare"
 	"dojo/Deferred",  "./model"],
 	function(require, when, on, domAttr, declare, lang, Deferred, Model){
 	return declare("dojox.app.ViewBase", null, {
+		// summary:
+		//		View base class with model & definition capabilities. Subclass must implement rendering capabilities.
 		constructor: function(params){
 			// summary:
-			//		View base classe with model & definition capabilities. Subclass must implement rendering capabilities.
+			//		Constructs a ViewBase instance.
 			// params:
 			//		view parameters, include:
 			//
@@ -12,7 +14,7 @@ define(["require", "dojo/when", "dojo/on", "dojo/dom-attr", "dojo/_base/declare"
 			//		- id: view id
 			//		- name: view name
 			//		- parent: parent view
-			//		- definition: view definition url
+			//		- definition: view definition module identifier
 			//		- children: children views
 			this.id = "";
 			this.name = "";
@@ -43,7 +45,7 @@ define(["require", "dojo/when", "dojo/on", "dojo/dom-attr", "dojo/_base/declare"
 		},
 
 		load: function(){
-			var defDef = this._loadViewDefinition();
+			var defDef = this._loadDefinition();
 			when(defDef, lang.hitch(this, function(definition){
 				if(definition){
 					lang.mixin(this, definition);
@@ -117,18 +119,18 @@ define(["require", "dojo/when", "dojo/on", "dojo/dom-attr", "dojo/_base/declare"
 			}
 		},
 
-		_loadViewDefinition: function(){
+		_loadDefinition: function(){
 			// summary:
 			//		Load view definition by configuration or by default.
 			// tags:
 			//		private
 			//
-			var _definitionDef = new Deferred();
+			var definitionDef = new Deferred();
 			var path;
 
 			if(this.definition && (this.definition === "none")){
-				_definitionDef.resolve(true);
-				return _definitionDef;
+				definitionDef.resolve(true);
+				return definitionDef;
 			}else if(this.definition){
 				path = this.definition.replace(/(\.js)$/, "");
 			}else{
@@ -146,11 +148,11 @@ define(["require", "dojo/when", "dojo/on", "dojo/dom-attr", "dojo/_base/declare"
 					loadFile = path.substring(index+2);
 				}
 				requireSignal = require.on("error", function(error){
-					if (_definitionDef.isResolved() || _definitionDef.isRejected()) {
+					if (definitionDef.isResolved() || definitionDef.isRejected()) {
 						return;
 					}
 					if(error.info[0] && (error.info[0].indexOf(loadFile)>= 0)){
-						_definitionDef.resolve(false);
+						definitionDef.resolve(false);
 						requireSignal.remove();
 					}
 				});
@@ -160,14 +162,14 @@ define(["require", "dojo/when", "dojo/on", "dojo/dom-attr", "dojo/_base/declare"
 				}
 
 				require([path], function(definition){
-					_definitionDef.resolve(definition);
+					definitionDef.resolve(definition);
 					requireSignal.remove();
 				});
 			}catch(e){
-				_definitionDef.reject(e);
+				definitionDef.reject(e);
 				requireSignal.remove();
 			}
-			return _definitionDef;
+			return definitionDef;
 		},
 
 		init: function(){

--- a/build/discoverAppConfig.js
+++ b/build/discoverAppConfig.js
@@ -6,7 +6,7 @@ define([
 	"build/process",
 	"dojox/json/ref"
 ], function(argv, fs, bc, messages, process, json){
-	var parseViews = function(mids, mainLayer, views){
+	var parseViews = function(mids, mainLayer, views, params){
 		for(var key in views){
 			// ignore naming starting with _ (jsonref adding is own stuff in there)
 			if(key.indexOf("_") == 0){
@@ -23,13 +23,27 @@ define([
 				mids.push(mid);
 			}
 			if(view.template){
+				// we need dojo/text to load templates, let's put it in the main layer in all cases
+				// as this will be shared by a lot of views
+				if(!params.text){
+					params.text = true;
+					bc.layers[mainLayer].include.push("dojo/text");
+				}
 				mids.push(view.template);
+			}
+			if(view.nls){
+				// we use nls let's add dojo/i18n to the main layer as it will be shared by a lot of views
+				if(!params.nls){
+					params.nls = true;
+					bc.layers[mainLayer].include.push("dojo/i18n");
+				}
+				mids.push(view.nls);
 			}
 			if(view.dependencies){
 				Array.prototype.splice.apply(mids, [ mids.length, 0 ].concat(view.dependencies));
 			}
 			if(view.views){
-				parseViews(mids, mainLayer, view.views);
+				parseViews(mids, mainLayer, view.views, params);
 			}
 		}
 	};
@@ -85,7 +99,7 @@ define([
 			}
 			// go into the view children
 			if(config.views){
-				parseViews(mids, mainLayer, config.views);
+				parseViews(mids, mainLayer, config.views, {});
 			}
 			Array.prototype.splice.apply(bc.layers[mainLayer].include, [bc.layers[mainLayer].length, 0].concat(mids));
 		}else{

--- a/tests/globalizedApp/build.profile.js
+++ b/tests/globalizedApp/build.profile.js
@@ -1,0 +1,31 @@
+require(["dojox/app/build/buildControlApp"], function(bc){
+});
+
+var profile = {
+	basePath: "..",
+	releaseDir: "./globalizedApp/release",
+	action: "release",
+	cssOptimize: "comments",
+	packages:[{
+		name: "dojo",
+		location: "../../../dojo"
+	},{
+		name: "dijit",
+		location: "../../../dijit"
+	},{
+		name: "globalizedApp",
+		location: "../../../dojox/app/tests/globalizedApp",
+		destLocation: "./dojox/app/tests/globalizedApp"
+	},{
+		name: "dojox",
+		location: "../../../dojox"
+	}],
+	layers: {
+		"globalizedApp/globalizedApp": {
+			include: [ "globalizedApp/index.html" ]
+		}
+	}
+};
+
+
+

--- a/tests/globalizedApp/config.json
+++ b/tests/globalizedApp/config.json
@@ -1,0 +1,32 @@
+{
+	"id": "globalizedApp",
+	"name": "globalizedApp",
+	"description": "A simple app to show how to plug custom controllers",
+
+	"loaderConfig": {
+		"paths": {
+			"globalizedApp": "../dojox/app/tests/globalizedApp"
+		}
+	},
+
+	"modules": [
+	],
+
+	"controllers": [
+		"dojox/app/controllers/History"
+	],
+	
+	"defaultView": "home",
+
+	"views": {
+		"home": {
+			"definition" : "none",
+			"template": "globalizedApp/home.html",
+			"nls": "globalizedApp/nls/home",
+			"dependencies":	[
+				"dojox/mobile/RoundRectList",
+				"dojox/mobile/ListItem"
+			]
+		}
+	}
+}

--- a/tests/globalizedApp/globalizedApp.js
+++ b/tests/globalizedApp/globalizedApp.js
@@ -1,0 +1,5 @@
+require(["dojox/app/main", "dojox/json/ref", "dojo/text!./config.json"],
+function(Application, jsonRef, config){
+	var config = jsonRef.fromJson(config);
+	Application(config);
+});

--- a/tests/globalizedApp/globalizedApp.profile.js
+++ b/tests/globalizedApp/globalizedApp.profile.js
@@ -1,0 +1,13 @@
+var profile = {
+	resourceTags:{
+		declarative: function(filename){
+	 		return /\.html?$/.test(filename); // tags any .html or .htm files as declarative
+	 	},
+		amd: function(filename){
+			return /\.js$/.test(filename);
+		},
+		copyOnly: function(filename, mid){
+			return mid == "globalizedApp/build.profile";
+		}
+	}
+};

--- a/tests/globalizedApp/home.html
+++ b/tests/globalizedApp/home.html
@@ -1,0 +1,9 @@
+<div class="view mblView">
+    <ul data-dojo-type="dojox/mobile/RoundRectList">
+        <li data-dojo-type="dojox/mobile/ListItem" data-dojo-props="'clickable':true, 'label': '${nls.label1}'">
+        </li>
+        <li data-dojo-type="dojox/mobile/ListItem" data-dojo-props="'clickable':true">
+			${nls.label2}
+        </li>
+    </ul>
+</div>

--- a/tests/globalizedApp/index.html
+++ b/tests/globalizedApp/index.html
@@ -4,7 +4,6 @@
 	<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"/> 
 		<meta name="apple-mobile-web-app-capable" content="yes" /> 
 		<title>Globalized App Test</title>
-		<link rel="stylesheet" href="../../../../dijit/themes/claro/claro.css">
 		<style>
 			html,body {
 				width: 100%;
@@ -20,15 +19,9 @@
 		<script type="text/javascript" src="../../../../dojox/mobile/deviceTheme.js"></script>
 		<script type="text/javascript" data-dojo-type="async: true" src="../../../../dojo/dojo.js"></script>
 		<script>
-			require(["dojox/app/main", "dojox/json/ref", "dojo/text!./config.json"],
-			function(Application, jsonRef, config){
-				var config = jsonRef.fromJson(config);
-				Application(config);
-			});
-
+			require(["./globalizedApp.js"]);
         </script>
-
 	</head>
-	<body class="claro">
+	<body>
 	</body>
 </html>

--- a/tests/globalizedApp/index.html
+++ b/tests/globalizedApp/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+	<head>
+	<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"/> 
+		<meta name="apple-mobile-web-app-capable" content="yes" /> 
+		<title>Globalized App Test</title>
+		<link rel="stylesheet" href="../../../../dijit/themes/claro/claro.css">
+		<style>
+			html,body {
+				width: 100%;
+				height: 100%;
+				background: #eee;
+				font-family: arial;
+				color: #333;
+				overflow: hidden;
+				margin: 0px;
+				padding: 0px;
+			}
+		</style>
+		<script type="text/javascript" src="../../../../dojox/mobile/deviceTheme.js"></script>
+		<script type="text/javascript" data-dojo-type="async: true" src="../../../../dojo/dojo.js"></script>
+		<script>
+			require(["dojox/app/main", "dojox/json/ref", "dojo/text!./config.json"],
+			function(Application, jsonRef, config){
+				var config = jsonRef.fromJson(config);
+				Application(config);
+			});
+
+        </script>
+
+	</head>
+	<body class="claro">
+	</body>
+</html>

--- a/tests/globalizedApp/nls/fr/home.js
+++ b/tests/globalizedApp/nls/fr/home.js
@@ -1,0 +1,4 @@
+define({
+	label1: "Etiquette Un",
+	label2: "Etiquette Deux"
+});

--- a/tests/globalizedApp/nls/home.js
+++ b/tests/globalizedApp/nls/home.js
@@ -1,0 +1,7 @@
+define({
+  root: {
+   	label1: "Label One",
+	label2: "Label Two"
+  },
+  fr: true
+});

--- a/tests/globalizedApp/package.json
+++ b/tests/globalizedApp/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "globalizedApp",
+	"dojoBuild": "globalizedApp.profile.js"
+}


### PR DESCRIPTION
The default view now let's the developer specify  a NLS root file in the config (nls property). Once done one can do things like

${nls.mylabel} in the template to be localized.

This is not dealing with name, description etc... properties of the config file which are anyway not used at all. 

This is for for #105
