### PR TITLE
Remove the noAutoLoadControllers config option and make it the default behavior.

### DIFF
--- a/build/discoverAppConfig.js
+++ b/build/discoverAppConfig.js
@@ -101,10 +101,6 @@ define([
 				// regular view
 				mids.push("dojox/app/View");
 			}
-			if(!config.noAutoLoadControllers){
-				// add auto loaded controllers
-				mids = ["dojox/app/controllers/Load", "dojox/app/controllers/Transition", "dojox/app/controllers/Layout"].concat(mids);
-			}
 			// go into the view children
 			if(config.views){
 				parseViews(mids, mainLayer, config.views, {});

--- a/main.js
+++ b/main.js
@@ -165,10 +165,6 @@ function(require, kernel, lang, declare, config, win, Evented, Deferred, when, h
 
 		setupControllers: function(){
 			// create application controller instance
-			if(!this.noAutoLoadControllers){
-				this.params.controllers =
-					["./controllers/Load", "./controllers/Transition", "./controllers/Layout"].concat(this.params.controllers?this.params.controllers:[]);
-			}
 			// move set _startView operation from history module to application
 			var currentHash = window.location.hash;
 			this._startView = (((currentHash && currentHash.charAt(0) == "#") ? currentHash.substr(1) : currentHash) || this.defaultView).split('&')[0];

--- a/tests/borderLayoutApp/config.json
+++ b/tests/borderLayoutApp/config.json
@@ -34,8 +34,6 @@
 
 	"modules": [],
 
-	"noAutoLoadControllers" : true,  
-	
 	"controllers": [
 		"dojox/app/controllers/History",
 		"dojox/app/controllers/Load",

--- a/tests/customApp/config.json
+++ b/tests/customApp/config.json
@@ -13,7 +13,10 @@
 	],
 
 	"controllers": [
-		"dojox/app/controllers/History"
+		"dojox/app/controllers/History",
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/controllers/Layout"
 	],
 	
 	"defaultView": "home",

--- a/tests/doh/lifecycleTest/config.json
+++ b/tests/doh/lifecycleTest/config.json
@@ -11,6 +11,9 @@
 	],
 	
 	"controllers": [
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/controllers/Layout",
 		"dojox/app/controllers/History"
 	],
 

--- a/tests/doh/simpleModelApp/config.json
+++ b/tests/doh/simpleModelApp/config.json
@@ -28,13 +28,7 @@
 	// of the application, how it processes the config or any other life cycle
 	// by creating and including one or more of these
 	"modules": [],
-	
-	// If noAutoLoadControllers is set to true a Load, Transition, and Layout controller 
-	// should be included in the list of controllers.  
-	// If noAutoLoadControllers is set to false (or not set) the default Load, Transition, and Layout  
-	// controllers will be added automatically.  
-	"noAutoLoadControllers" : true,  
-	
+		
 	"controllers": [
 		"dojox/app/controllers/History",
 		"dojox/app/controllers/Load",

--- a/tests/globalizedApp/config.json
+++ b/tests/globalizedApp/config.json
@@ -15,9 +15,12 @@
 	],
 
 	"controllers": [
-		"dojox/app/controllers/History"
+		"dojox/app/controllers/History",
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/controllers/Layout"
 	],
-	
+		
 	"defaultView": "home",
 
 	"views": {

--- a/tests/layoutApp/config.json
+++ b/tests/layoutApp/config.json
@@ -32,9 +32,12 @@
 	"modules": [],
 	
 	"controllers": [
-		"dojox/app/controllers/History"
+		"dojox/app/controllers/History",
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/controllers/Layout"
 	],
-
+	
 	//stores we are using
 	"stores": {
 	   "namesStore":{

--- a/tests/layoutApp2/config.json
+++ b/tests/layoutApp2/config.json
@@ -31,8 +31,6 @@
 
 	"modules": [],
 	
-	"noAutoLoadControllers" : true,  
-	
 	"controllers": [
 		"dojox/app/controllers/History",
 		"dojox/app/controllers/Load",

--- a/tests/layoutApp2/configOld.json
+++ b/tests/layoutApp2/configOld.json
@@ -32,7 +32,10 @@
 	"modules": [],
 	
 	"controllers": [
-		"dojox/app/controllers/History"
+		"dojox/app/controllers/History",
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/controllers/Layout"
 	],
 
 	//stores we are using

--- a/tests/modelApp/config.json
+++ b/tests/modelApp/config.json
@@ -30,14 +30,11 @@
 		//"dojox/app/module/lifecycle"
 	],
 	
-	// If noAutoLoadControllers is set to true a Load, Transition, and Layout controller 
-	// should be included in the list of controllers.  
-	// If noAutoLoadControllers is set to false (or not set) the default Load, Transition, and Layout  
-	// controllers will be added automatically.  
-	"noAutoLoadControllers" : false,  
-
 	"controllers": [
-		"dojox/app/controllers/History"
+		"dojox/app/controllers/History",
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/controllers/Layout"
 	],
 
 	//stores we are using 

--- a/tests/multiSceneApp/config.json
+++ b/tests/multiSceneApp/config.json
@@ -25,7 +25,10 @@
 	],
 	
 	"controllers": [
-		"dojox/app/controllers/History"
+		"dojox/app/controllers/History",
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/controllers/Layout"
 	],
 
 	//stores we are using 

--- a/tests/scrollableTestApp/config-phone.json
+++ b/tests/scrollableTestApp/config-phone.json
@@ -44,8 +44,12 @@
 	],
 
 	"controllers": [
-		"dojox/app/controllers/History"
+		"dojox/app/controllers/History",
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/controllers/Layout"
 	],
+
 	//stores we are using
 	"stores": {
 		"repeatStore":{

--- a/tests/scrollableTestApp/config-tablet.json
+++ b/tests/scrollableTestApp/config-tablet.json
@@ -45,8 +45,12 @@
 	],
 
 	"controllers": [
-		"dojox/app/controllers/History"
+		"dojox/app/controllers/History",
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/controllers/Layout"
 	],
+
 	//stores we are using
 	"stores": {
 		"repeatStore":{

--- a/tests/scrollableTestApp2/config-phone.json
+++ b/tests/scrollableTestApp2/config-phone.json
@@ -43,7 +43,6 @@
 		"scrollableTestApp/scrollableTestApp"
 	],
 
-	"noAutoLoadControllers" : true,  	
 	"controllers": [
 		"dojox/app/controllers/History",
 		"dojox/app/controllers/Load",

--- a/tests/scrollableTestApp2/config-tablet.json
+++ b/tests/scrollableTestApp2/config-tablet.json
@@ -45,7 +45,6 @@
 		"scrollableTestApp/scrollableTestApp"
 	],
 
-	"noAutoLoadControllers" : true,  	
 	"controllers": [
 		"dojox/app/controllers/History",
 		"dojox/app/controllers/Load",

--- a/tests/simpleModelApp/config.json
+++ b/tests/simpleModelApp/config.json
@@ -30,13 +30,7 @@
 	// of the application, how it processes the config or any other life cycle
 	// by creating and including one or more of these
 	"modules": [],
-	
-	// If noAutoLoadControllers is set to true a Load, Transition, and Layout controller 
-	// should be included in the list of controllers.  
-	// If noAutoLoadControllers is set to false (or not set) the default Load, Transition, and Layout  
-	// controllers will be added automatically.  
-	"noAutoLoadControllers" : true,  
-	
+
 	"controllers": [
 		"dojox/app/controllers/History",
 		"dojox/app/controllers/Load",


### PR DESCRIPTION
Remove the noAutoLoadControllers config option and make it the default behavior so that all controllers must be listed in the controllers section of the config. I have also updated the test applications to list the controllers in the config
