### PR TITLE
Update the layout support to take a "-" to indicate that a view should be removed (or hidden).

### DIFF
--- a/controllers/BorderLayout.js
+++ b/controllers/BorderLayout.js
@@ -25,7 +25,7 @@ function(declare, domAttr, domStyle, LayoutBase, BorderContainer, StackContainer
 
 			if(!this.borderLayoutCreated){ // If the BorderContainer has not been created yet, create it.
 				this.borderLayoutCreated = true;
-				bc = new BorderContainer({id:"App-BC", style:'height:100%;width:100%;border:1px solid black'});
+				bc = new BorderContainer({id:this.app.id+"-BC", style:'height:100%;width:100%;border:1px solid black'});
 				event.view.parent.domNode.appendChild(bc.domNode);  // put the border container into the parent (app)
 
 				bc.startup();  // startup the BorderContainer
@@ -78,15 +78,16 @@ function(declare, domAttr, domStyle, LayoutBase, BorderContainer, StackContainer
 			if(!view){
 				return;
 			}
-			var sc = registry.byId(event.view.parent.id+"-"+event.view.constraint);
-			var cp = registry.byId(event.view.id+"-cp-"+event.view.constraint);
 
 			var parentSelChild = this._getSelectedChild(parent, view.constraint);
 			if(view !== parentSelChild){
+				var sc = registry.byId(event.view.parent.id+"-"+event.view.constraint);
+				var cp = registry.byId(event.view.id+"-cp-"+event.view.constraint);
 				if(sc && cp){
 					if(sc.removedFromBc){
 						sc.removedFromBc = false;
-						registry.byId("App-BC").addChild(sc);
+						registry.byId(this.app.id+"-BC").addChild(sc);
+						domStyle.set(view.domNode, "display", "");
 					}
 					domStyle.set(cp.domNode, "display", "");
 					sc.selectChild(cp);
@@ -113,16 +114,14 @@ function(declare, domAttr, domStyle, LayoutBase, BorderContainer, StackContainer
 			if(!view){
 				return;
 			}
-			var bc = registry.byId("App-BC");
-			var sc = registry.byId(event.view.parent.id+"-"+event.view.constraint);
-			var cp = registry.byId(event.view.id+"-cp-"+event.view.constraint);
 
 			var parentSelChild = this._getSelectedChild(parent, view.constraint);
 			if(view == parentSelChild){
+				var bc = registry.byId(this.app.id+"-BC");
+				var sc = registry.byId(event.view.parent.id+"-"+event.view.constraint);
 				if(bc && sc){
 					sc.removedFromBc = true;
 					bc.removeChild(sc);
-					//domStyle.set(cp.domNode, "display", "none");
 				}
 				parent.selectedChildren[view.constraint] = null;
 			}

--- a/controllers/BorderLayout.js
+++ b/controllers/BorderLayout.js
@@ -71,7 +71,7 @@ function(declare, domAttr, domStyle, LayoutBase, BorderContainer, StackContainer
 			//		|	on.emit(this.app.evented, "layoutView", view);
 			//
 			// event: Object
-			// |		{"parent":parent, "view":view}
+			// |		{"parent":parent, "view":view, "removeView": false}
 			var parent = event.parent || this.app;
 			var view = event.view;
 
@@ -80,7 +80,17 @@ function(declare, domAttr, domStyle, LayoutBase, BorderContainer, StackContainer
 			}
 
 			var parentSelChild = this._getSelectedChild(parent, view.constraint);
-			if(view !== parentSelChild){
+			if(event.removeView){ // if the view is being removed flag it as removed and remove the child from the bc, and set selectedChildren entry to null
+				if(view == parentSelChild){
+					var bc = registry.byId(this.app.id+"-BC");
+					var sc = registry.byId(event.view.parent.id+"-"+event.view.constraint);
+					if(bc && sc){
+						sc.removedFromBc = true;
+						bc.removeChild(sc);
+					}
+					parent.selectedChildren[view.constraint] = null;
+				}
+			}else if(view !== parentSelChild){
 				var sc = registry.byId(event.view.parent.id+"-"+event.view.constraint);
 				var cp = registry.byId(event.view.id+"-cp-"+event.view.constraint);
 				if(sc && cp){
@@ -95,39 +105,6 @@ function(declare, domAttr, domStyle, LayoutBase, BorderContainer, StackContainer
 				}
 				parent.selectedChildren[view.constraint] = view;
 			}
-		},
-
-		removeView: function(event){
-			// summary:
-			//		Response to dojox/app "removeView" event.
-			//
-			// example:
-			//		Use dojo/on.emit to trigger "removeView" event, and this function will response the event. For example:
-			//		|	on.emit(this.app.evented, "removeView", view);
-			//
-			// event: Object
-			// |		{"parent":parent, "view":view}
-
-			var parent = event.parent || this.app;
-			var view = event.view;
-
-			if(!view){
-				return;
-			}
-
-			var parentSelChild = this._getSelectedChild(parent, view.constraint);
-			if(view == parentSelChild){
-				var bc = registry.byId(this.app.id+"-BC");
-				var sc = registry.byId(event.view.parent.id+"-"+event.view.constraint);
-				if(bc && sc){
-					sc.removedFromBc = true;
-					bc.removeChild(sc);
-				}
-				parent.selectedChildren[view.constraint] = null;
-			}
-		}
-		
-
+		}		
 	});
-
 });

--- a/controllers/BorderLayout.js
+++ b/controllers/BorderLayout.js
@@ -1,6 +1,6 @@
-define(["dojo/_base/declare", "dojo/dom-attr", "./LayoutBase","dijit/layout/BorderContainer",
+define(["dojo/_base/declare", "dojo/dom-attr", "dojo/dom-style", "./LayoutBase","dijit/layout/BorderContainer",
 		"dijit/layout/StackContainer", "dijit/layout/ContentPane", "dijit/registry"],
-function(declare, domAttr, LayoutBase, BorderContainer, StackContainer, ContentPane, registry){
+function(declare, domAttr, domStyle, LayoutBase, BorderContainer, StackContainer, ContentPane, registry){
 	// module:
 	//		dojox/app/controllers/BorderLayout
 	// summary:
@@ -25,7 +25,7 @@ function(declare, domAttr, LayoutBase, BorderContainer, StackContainer, ContentP
 
 			if(!this.borderLayoutCreated){ // If the BorderContainer has not been created yet, create it.
 				this.borderLayoutCreated = true;
-				bc = new BorderContainer({style:'height:100%;width:100%;border:1px solid black'});
+				bc = new BorderContainer({id:"App-BC", style:'height:100%;width:100%;border:1px solid black'});
 				event.view.parent.domNode.appendChild(bc.domNode);  // put the border container into the parent (app)
 
 				bc.startup();  // startup the BorderContainer
@@ -84,11 +84,50 @@ function(declare, domAttr, LayoutBase, BorderContainer, StackContainer, ContentP
 			var parentSelChild = this._getSelectedChild(parent, view.constraint);
 			if(view !== parentSelChild){
 				if(sc && cp){
+					if(sc.removedFromBc){
+						sc.removedFromBc = false;
+						registry.byId("App-BC").addChild(sc);
+					}
+					domStyle.set(cp.domNode, "display", "");
 					sc.selectChild(cp);
+					sc.resize();
 				}
 				parent.selectedChildren[view.constraint] = view;
 			}
+		},
+
+		removeView: function(event){
+			// summary:
+			//		Response to dojox/app "removeView" event.
+			//
+			// example:
+			//		Use dojo/on.emit to trigger "removeView" event, and this function will response the event. For example:
+			//		|	on.emit(this.app.evented, "removeView", view);
+			//
+			// event: Object
+			// |		{"parent":parent, "view":view}
+
+			var parent = event.parent || this.app;
+			var view = event.view;
+
+			if(!view){
+				return;
+			}
+			var bc = registry.byId("App-BC");
+			var sc = registry.byId(event.view.parent.id+"-"+event.view.constraint);
+			var cp = registry.byId(event.view.id+"-cp-"+event.view.constraint);
+
+			var parentSelChild = this._getSelectedChild(parent, view.constraint);
+			if(view == parentSelChild){
+				if(bc && sc){
+					sc.removedFromBc = true;
+					bc.removeChild(sc);
+					//domStyle.set(cp.domNode, "display", "none");
+				}
+				parent.selectedChildren[view.constraint] = null;
+			}
 		}
+		
 
 	});
 

--- a/controllers/LayoutBase.js
+++ b/controllers/LayoutBase.js
@@ -19,6 +19,7 @@ function(lang, declare, has, win, config, topic, domStyle, domGeom, Controller){
 			this.events = {
 				"initLayout": this.initLayout,
 				"layoutView": this.layoutView,
+				"removeView": this.removeView,
 				"resize": this.onResize
 			};
 			// if we are using dojo mobile & we are hiding address bar we need to be bit smarter and listen to
@@ -36,7 +37,9 @@ function(lang, declare, has, win, config, topic, domStyle, domGeom, Controller){
 			// this is needed to resize the children on an orientation change or a resize of the browser.
 			// it was being done in _doResize, but was not needed for every call to _doResize.
 			for(var item in this.app.selectedChildren){  // need this to handle all selectedChildren
-				this._doResize(this.app.selectedChildren[item]);
+				if(this.app.selectedChildren[item]) {
+					this._doResize(this.app.selectedChildren[item]);
+				}
 			}
 			
 		},
@@ -178,6 +181,37 @@ function(lang, declare, has, win, config, topic, domStyle, domGeom, Controller){
 			// call _doResize for parent and view here, doResize will no longer call it for all children.
 			this._doResize(parent);  
 			this._doResize(view);
+		},
+
+		removeView: function(event){
+			// summary:
+			//		Response to dojox/app "removeView" event.
+			//
+			// example:
+			//		Use dojo/on.emit to trigger "removeView" event, and this function will response the event. For example:
+			//		|	on.emit(this.app.evented, "removeView", view);
+			//
+			// event: Object
+			// |		{"parent":parent, "view":view}
+
+			var parent = event.parent || this.app;
+			var view = event.view;
+
+			if(!view){
+				return;
+			}
+			
+			// if the parent has a child in the view constraint it has to be hidden, and this view displayed.
+			var parentSelChild = this._getSelectedChild(parent, view.constraint); 
+			if(view == parentSelChild){
+				domStyle.set(view.domNode, "display", "none");
+				parent.selectedChildren[view.constraint] = null;  // remove from selectedChildren
+			}
+			// do selected view layout
+			// call _doResize for parent and view here, doResize will no longer call it for all children.
+			this._doResize(parent);  
+			this._doResize(view);
 		}
+		
 	});
 });

--- a/controllers/LayoutBase.js
+++ b/controllers/LayoutBase.js
@@ -19,7 +19,6 @@ function(lang, declare, has, win, config, topic, domStyle, domGeom, Controller){
 			this.events = {
 				"initLayout": this.initLayout,
 				"layoutView": this.layoutView,
-				"removeView": this.removeView,
 				"resize": this.onResize
 			};
 			// if we are using dojo mobile & we are hiding address bar we need to be bit smarter and listen to
@@ -156,7 +155,7 @@ function(lang, declare, has, win, config, topic, domStyle, domGeom, Controller){
 			//		|	on.emit(this.app.evented, "layoutView", view);
 			//
 			// event: Object
-			// |		{"parent":parent, "view":view}
+			// |		{"parent":parent, "view":view, "removeView": boolean}
 
 			var parent = event.parent || this.app;
 			var view = event.view;
@@ -167,7 +166,12 @@ function(lang, declare, has, win, config, topic, domStyle, domGeom, Controller){
 			
 			// if the parent has a child in the view constraint it has to be hidden, and this view displayed.
 			var parentSelChild = this._getSelectedChild(parent, view.constraint); 
-			if(view !== parentSelChild){
+			if(event.removeView){  // if this view is being removed set display to none and the selectedChildren entry to null
+				if(view == parentSelChild){
+					domStyle.set(view.domNode, "display", "none");
+					parent.selectedChildren[view.constraint] = null;  // remove from selectedChildren
+				}
+			}else if(view !== parentSelChild){
 				if(parentSelChild){
 				//	domStyle.set(parentSelChild.domNode, "zIndex", 25);
 					domStyle.set(parentSelChild.domNode, "display", "none");
@@ -181,37 +185,6 @@ function(lang, declare, has, win, config, topic, domStyle, domGeom, Controller){
 			// call _doResize for parent and view here, doResize will no longer call it for all children.
 			this._doResize(parent);  
 			this._doResize(view);
-		},
-
-		removeView: function(event){
-			// summary:
-			//		Response to dojox/app "removeView" event.
-			//
-			// example:
-			//		Use dojo/on.emit to trigger "removeView" event, and this function will response the event. For example:
-			//		|	on.emit(this.app.evented, "removeView", view);
-			//
-			// event: Object
-			// |		{"parent":parent, "view":view}
-
-			var parent = event.parent || this.app;
-			var view = event.view;
-
-			if(!view){
-				return;
-			}
-			
-			// if the parent has a child in the view constraint it has to be hidden, and this view displayed.
-			var parentSelChild = this._getSelectedChild(parent, view.constraint); 
-			if(view == parentSelChild){
-				domStyle.set(view.domNode, "display", "none");
-				parent.selectedChildren[view.constraint] = null;  // remove from selectedChildren
-			}
-			// do selected view layout
-			// call _doResize for parent and view here, doResize will no longer call it for all children.
-			this._doResize(parent);  
-			this._doResize(view);
-		}
-		
+		}		
 	});
 });

--- a/controllers/Transition.js
+++ b/controllers/Transition.js
@@ -451,7 +451,7 @@ function(lang, declare, has, on, Deferred, when, domStyle, transit, Controller){
 			}
 			// remove is not a Deferred object, so Deferred.when is no needed.
 			if(remove !== current){
-				this.app.log("> in Transition._doRemoveTransition called _doRemoveTransition but remove !== current, it should be.");
+				this.app.log("> in Transition._doRemoveTransition called _doRemoveTransition but remove !== current, nothing to remove.");
 				return;
 			}else{
 				// remove view == current view, refresh current view

--- a/tests/borderLayoutApp/config.json
+++ b/tests/borderLayoutApp/config.json
@@ -42,12 +42,19 @@
 	//	"dojox/app/controllers/Layout"         // this test can work with either Layout or BorderLayout
 	],
 
-	// these are the possilbe defaultTransitions
-	"defaultTransition": "slide",
+	// these are the possible defaultTransitions, 
+	// the defaultTransition is only used if transition is not set in the config and it is not set or defaulted on the transitionEvent
+	//"defaultTransition": "slide",
 	//"defaultTransition": "none",
 	//"defaultTransition": "fade",
 	//"defaultTransition": "flip",     // Note: flip does not work with a BorderLayout Controller
 
+	// these are the possible transitions, 
+	// if a transition is set on a view or parent it will override the transition set on the transitionEvent or the defaultTransition in the config.
+	"transition": "slide",
+	//"transition": "none",
+	//"transition": "fade",
+	//"transition": "flip",     // Note: flip does not work with a BorderLayout Controller
 
 	//stores we are using 
 	"stores": {

--- a/tests/borderLayoutApp/templates/view3.html
+++ b/tests/borderLayoutApp/templates/view3.html
@@ -8,23 +8,23 @@
 				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'originalSet',target:'view1+view9+view3+view7+view5',url:'#view1+view9+view3+view7+view5'}">
 					View 1+9+3+7+5'
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1',url:'#view1'}">
-					View 1 top
+				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1-view8',url:'#view1-view8'}">
+					View top 1-8 
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view2',target:'view2',url:'#view2'}">
-					View 2 top
+				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view2-view7',target:'view2-view7',url:'#view2-view7'}">
+					View 2-7 top
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view3',target:'view3',url:'#view3'}">
-					View 3 left
+				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view3-view9',target:'view3-view9',url:'#view3-view9'}">
+					View left 3-9
 				</li>
 				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
 					View 4 left
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view5',target:'view5',url:'#view5'}">
-					View 5 center
+				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view5-view10',target:'view5-view10',url:'#view5-view10'}">
+					View cneter 5-10 
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view6',target:'view6',url:'#view6'}">
-					View 6 center
+				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view6-view10',target:'view6-view10',url:'#view6-view10'}">
+					View center 6-10 
 				</li>
 				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view7',target:'view7',url:'#view7'}">
 					View 7 right

--- a/tests/borderLayoutApp/templates/view4.html
+++ b/tests/borderLayoutApp/templates/view4.html
@@ -8,23 +8,23 @@
 				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'originalSet',target:'view1+view9+view3+view7+view5',url:'#view1+view9+view3+view7+view5'}">
 					View 1+9+3+7+5'
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1',url:'#view1'}">
-					View 1 top
+				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1-view8',url:'#view1-view8'}">
+					View 1-8 top
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view2',target:'view2',url:'#view2'}">
-					View 2 top
+				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view2-view7',target:'view2-view7',url:'#view2-view7'}">
+					View 2-7 top
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view3',target:'view3',url:'#view3'}">
-					View 3 left
+				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view3-view9',target:'view3-view9',url:'#view3-view9'}">
+					View left 3-9
 				</li>
 				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
 					View 4 left
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view5',target:'view5',url:'#view5'}">
-					View 5 center
+				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view5-view10',target:'view5-view10',url:'#view5-view10'}">
+					View center 5-10 
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view6',target:'view6',url:'#view6'}">
-					View 6 center
+				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view6-view10',target:'view6-view10',url:'#view6-view10'}">
+					View center 6-10 
 				</li>
 				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view7',target:'view7',url:'#view7'}">
 					View 7 right

--- a/tests/borderLayoutApp/templates/view5.html
+++ b/tests/borderLayoutApp/templates/view5.html
@@ -17,5 +17,12 @@
 				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
 					View 4 left
 				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'-view7',target:'-view7',url:'#-view7'}">
+					Remove view7 right
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'-view8',target:'-view8',url:'#-view8'}">
+					Remove view8 right
+				</li>
+					
 			</ul>
 </div>

--- a/tests/borderLayoutApp/templates/view6.html
+++ b/tests/borderLayoutApp/templates/view6.html
@@ -3,9 +3,7 @@
     <h3 style='background-color:green;'>View 6 center.</h3>
     <h3 style='background-color:green;'>View 6 center.</h3>
     <h3 style='background-color:green;'>View 6 center.</h3>
-    <h3 style='background-color:green;'>View 6 center.</h3>
-    <h3 style='background-color:green;'>View 6 center.</h3>
-			<ul data-dojo-type="dojox/mobile/RoundRectList">
+    		<ul data-dojo-type="dojox/mobile/RoundRectList">
 				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1',url:'#view1'}">
 					View 1 top
 				</li>
@@ -17,6 +15,12 @@
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
 					View 4 left
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'-view7',target:'-view7',url:'#-view7'}">
+					Remove view7 right
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'-view8',target:'-view8',url:'#-view8'}">
+					Remove view8 right
 				</li>
 			</ul>
 </div>

--- a/tests/layoutApp/config.json
+++ b/tests/layoutApp/config.json
@@ -72,11 +72,19 @@
 	//the name of the view to load when the app is initialized.
 	"defaultView": "simple",
 
-	// these are the possilbe defaultTransitions
+	// these are the possible defaultTransitions, 
+	// the defaultTransition is only used if transition is not set in the config and it is not set or defaulted on the transitionEvent
 	//"defaultTransition": "slide",
 	//"defaultTransition": "none",
 	//"defaultTransition": "fade",
-	"defaultTransition": "flip",     
+	//"defaultTransition": "flip",     // Note: flip does not work with a BorderLayout Controller
+
+	// these are the possible transitions, 
+	// if a transition is set on a view or parent it will override the transition set on the transitionEvent or the defaultTransition in the config.
+	//"transition": "slide",
+	//"transition": "none",
+	//"transition": "fade",
+	"transition": "flip",
 
 	"views": {
 		"simple":{
@@ -95,17 +103,19 @@
 					}           
                 }
             },
+			"transition": "fade",
 			"defaultView": "repeatList",
-			"defaultTransition": "slide",
 			"definition": "none",
 
 			"views": {
 				"repeatList":{
+					"transition": "slide",
 					"definition" : "layoutApp/views/repeat.js",
 					"template": "layoutApp/templates/repeat.html",
 					"dependencies":["dojox/mobile/TextBox"]
 				},
 				"repeatDetails":{
+					"transition": "flip",
 					"definition" : "layoutApp/views/repeatDetails.js",
 					"template": "layoutApp/templates/repeatDetails.html",
 					"dependencies":["dojox/mobile/TextBox"]

--- a/tests/layoutApp/css/layoutApp.css
+++ b/tests/layoutApp/css/layoutApp.css
@@ -114,4 +114,5 @@ div .navPane {
 	width:250px;
 	border-right:1px solid black;
 	background-color: #C5CCD3;
+	z-index:100;	
 }

--- a/tests/layoutApp2/css/layoutApp.css
+++ b/tests/layoutApp2/css/layoutApp.css
@@ -114,4 +114,5 @@ div .navPane {
 	width:250px;
 	border-right:1px solid black;
 	background-color: #C5CCD3;
+	z-index:100;
 }

--- a/tests/layoutApp2/templates/navigation.html
+++ b/tests/layoutApp2/templates/navigation.html
@@ -13,6 +13,9 @@
 				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'repeat',target:'repeat,repeatList',url:'#repeat,repeatList'}">
 					Repeat Data Binding
 				</li>
+				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'repeat',target:'navigation+repeat,repeatList',url:'#navigation+repeat,repeatList'}">
+					Nav + Repeat Data Binding
+				</li>
 				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'generate',target:'generate',url:'#generate'}">
 					Simple Form Generate
 				</li>

--- a/tests/layoutApp2/templates/repeat.html
+++ b/tests/layoutApp2/templates/repeat.html
@@ -20,4 +20,22 @@
 			</div>
         </div>
 	</form>
+			<ul data-dojo-type="dojox.mobile.RoundRectList">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'-repeat',target:'-repeat',url:'#-repeat'}">
+					Remove repeat view
+				</li>					
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'-navigation',target:'-navigation',url:'#-navigation'}">
+					Remove navigation view
+				</li>					
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'navigation',target:'navigation',url:'#navigation'}">
+					Add navigation view
+				</li>					
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'repeat,repeatList-navigation',target:'repeat,repeatList-navigation',url:'#repeat,repeatList-navigation'}">
+					Remove navigation view. leave repeat,repeatList
+				</li>					
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'repeat,repeatList+navigation',target:'repeat,repeatList+navigation',url:'#repeat,repeatList+navigation'}">
+					Add navigation view to repeat,repeatList
+				</li>					
+			</ul>
+	
 </div>

--- a/tests/scrollableTestApp/config-phone.json
+++ b/tests/scrollableTestApp/config-phone.json
@@ -76,12 +76,25 @@
 	//the name of the view to load when the app is initialized.
 	"defaultView": "configuration,ScrollableListSelection",
 
-	"defaultTransition": "slide",
+	// these are the possible defaultTransitions, 
+	// the defaultTransition is only used if transition is not set in the config and it is not set or defaulted on the transitionEvent
+	//"defaultTransition": "slide",
+	//"defaultTransition": "none",
+	//"defaultTransition": "fade",
+	"defaultTransition": "flip",     // Note: flip does not work with a BorderLayout Controller
+
+	// these are the possible transitions, 
+	// if a transition is set on a view or parent it will override the transition set on the transitionEvent or the defaultTransition in the config.
+	//"transition": "slide",
+	//"transition": "none",
+	//"transition": "fade",
+	//"transition": "flip",
+
 	//views are groups of views and models loaded at once
 	"views": {
 		"configuration": {
 			"defaultView": "ScrollableListSelection",
-			"defaultTransition": "slide",
+			"transition": "slide",
 			"definition": "none",
 
 			"views": {
@@ -93,15 +106,19 @@
 
 		
 		"TestInfo": {
+			"transition": "none",
 			"template": "scrollableTestApp/templates/TestInfo.html"
 		},
 		"Scrollable1": {
+			"transition": "slide",
 			"template": "scrollableTestApp/templates/Scrollable1.html"
 		},
 		"Scrollable1P": {
+			"transition": "flip",
 			"template": "scrollableTestApp/templates/Scrollable1P.html"
 		},
 		"Scrollable2": {
+			"transition": "fade",
 			"template": "scrollableTestApp/templates/Scrollable2.html"
 		},
 		"Scrollable3": {
@@ -113,10 +130,12 @@
 		"Scrollable5": {
 			"template": "scrollableTestApp/templates/Scrollable5.html"
 		},
-		"ListItem-domButtons": {
+		"ListItemDomButtons": {
+			"definition": "scrollableTestApp/views/ListItem-domButtons",
 			"template": "scrollableTestApp/templates/ListItem-domButtons.html"
 		},
-		"ListItem-domButtons2": {
+		"ListItemDomButtons2": {
+			"definition": "scrollableTestApp/views/ListItem-domButtons2",
 			"template": "scrollableTestApp/templates/ListItem-domButtons2.html"
 		},
 

--- a/tests/scrollableTestApp/config-tablet.json
+++ b/tests/scrollableTestApp/config-tablet.json
@@ -79,12 +79,25 @@
 	//the name of the view to load when the app is initialized.
 	"defaultView": "TestInfo",
 
-	"defaultTransition": "slide",
+	// these are the possible defaultTransitions, 
+	// the defaultTransition is only used if transition is not set in the config and it is not set or defaulted on the transitionEvent
+	//"defaultTransition": "slide",
+	//"defaultTransition": "none",
+	//"defaultTransition": "fade",
+	"defaultTransition": "flip",     // Note: flip does not work with a BorderLayout Controller
+
+	// these are the possible transitions, 
+	// if a transition is set on a view or parent it will override the transition set on the transitionEvent or the defaultTransition in the config.
+	//"transition": "slide",
+	//"transition": "none",
+	//"transition": "fade",
+	//"transition": "flip",
+
 	//views are groups of views and models loaded at once
 	"views": {
 		"configuration": {
 			"defaultView": "ScrollableListSelection",
-			"defaultTransition": "slide",
+			"transition": "slide",
 			"definition": "none",
 
 			"views": {
@@ -96,15 +109,19 @@
 		
 		
 		"TestInfo": {
+			"transition": "none",
 			"template": "scrollableTestApp/templates/TestInfo.html"
 		},
 		"Scrollable1": {
+			"transition": "slide",
 			"template": "scrollableTestApp/templates/Scrollable1.html"
 		},
 		"Scrollable1P": {
+			"transition": "flip",
 			"template": "scrollableTestApp/templates/Scrollable1P.html"
 		},
 		"Scrollable2": {
+			"transition": "fade",
 			"template": "scrollableTestApp/templates/Scrollable2.html"
 		},
 		"Scrollable3": {
@@ -116,16 +133,18 @@
 		"Scrollable5": {
 			"template": "scrollableTestApp/templates/Scrollable5.html"
 		},
-		"ListItem-domButtons": {
+		"ListItemDomButtons": {
+			"definition": "scrollableTestApp/views/ListItem-domButtons",
 			"template": "scrollableTestApp/templates/ListItem-domButtons.html"
 		},
-		"ListItem-domButtons2": {
+		"ListItemDomButtons2": {
+			"definition": "scrollableTestApp/views/ListItem-domButtons2",
 			"template": "scrollableTestApp/templates/ListItem-domButtons2.html"
 		},
 		
 		"repeatDetails": {
 			"template": "scrollableTestApp/templates/repeatDetails.html",
-			"defaultTransition": "slide"
+			"transition": "slide"
 		}
 	}
 }

--- a/tests/scrollableTestApp/css/tablet.css
+++ b/tests/scrollableTestApp/css/tablet.css
@@ -77,4 +77,5 @@ div .navPane {
 	width:250px;
 	border-right:1px solid black;
 	background-color: #C5CCD3;
+	z-index:100;
 }

--- a/tests/scrollableTestApp/src.js
+++ b/tests/scrollableTestApp/src.js
@@ -13,12 +13,5 @@ require(["dojox/app/main", "dojox/json/ref"],
 		var config = json.fromJson(configJson);
 		config.isTablet = isTablet;
 		Application(config);
-			 	
-	 	window.removeScrollableItem = function(index){
-				var repeatmodel = app.loadedModels.repeatmodels;
-				repeatmodel.model.splice(index, 1);
-				return false; 	 		
-	 	};
-
 	});
 });

--- a/tests/scrollableTestApp/templates/ListItem-domButtons.html
+++ b/tests/scrollableTestApp/templates/ListItem-domButtons.html
@@ -18,85 +18,85 @@
 		</div>
 
 		<ul data-dojo-type="dojox.mobile.RoundRectList">
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 1
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 2
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 3
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 4
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 5
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 6
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 7
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 8
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 9
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 10
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 11
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 12
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 13
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 14
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 15
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 16
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 17
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 18
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 19
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 20
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 21
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 22
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 23
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 24
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 25
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 26
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 27
 			</li>
 		</ul>

--- a/tests/scrollableTestApp/templates/configuration/ScrollableListSelection.html
+++ b/tests/scrollableTestApp/templates/configuration/ScrollableListSelection.html
@@ -12,7 +12,7 @@
 					transitionOptions: {title:'List',target: 'TestInfo', url: '#TestInfo'}">
 					<div class="textBox">
 						<div class="subject">Test Instructions</div>
-						Test instructions, notes and known problems				
+						Test instructions, notes and known problems (transition none)				
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
@@ -20,7 +20,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable1', url: '#Scrollable1'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list One</div>
-						Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint	 (transition slide)				
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
@@ -28,7 +28,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable1P', url: '#Scrollable1P'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list OneP</div>
-						Programmatic creation of WidgetList uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+						Programmatic creation of WidgetList uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint  (transition flip)					
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
@@ -36,7 +36,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable2', url: '#Scrollable2'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list Two</div>
-						Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint  (transition fade)
 					</div>				
 				</li>
 			
@@ -49,30 +49,29 @@
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
-					data-dojo-props="clickable: true, noArrow: true, 
+				data-dojo-props="clickable: true, noArrow: true, transition:'fade',
 					transitionOptions: {title:'List',target: 'Scrollable4', url: '#Scrollable4'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list Four</div>
-						Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer					
+					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
-					data-dojo-props="clickable: true, noArrow: true, 
+				data-dojo-props="clickable: true, noArrow: true, transition:'flip', 
 					transitionOptions: {title:'List',target: 'Scrollable5', url: '#Scrollable5'}">
 					<div class="textBox">
 					<div class="subject">Scrollable list Five</div>
-						Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer					
+					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
 					data-dojo-props="clickable: true, noArrow: true, 
-					transitionOptions: {title:'List',target: 'ListItem-domButtons', url: '#ListItem-domButtons'}">
+					transitionOptions: {title:'List',target: 'ListItemDomButtons', url: '#ListItemDomButtons'}">
 					<div class="textBox">
 						<div class="subject">Dojox Mobile Test</div>
-						A copy of the dojox/mobile test test_ListItem-domButtons, (removed height="auto"), had used it to avoid problem with initially showing this page.					
+						A copy of the dojox/mobile test test_ListItemDomButtons, (removed height="auto"), had used it to avoid problem with initially showing this page.					
 					</div>				
 				</li>
 			</ul>
 		</div>
 	</div>
-</div>

--- a/tests/scrollableTestApp/templates/tablet/ViewScrollableLists.html
+++ b/tests/scrollableTestApp/templates/tablet/ViewScrollableLists.html
@@ -11,7 +11,7 @@
 				transitionOptions: {title:'List',target: 'TestInfo', url: '#TestInfo'}">
 				<div class="textBox">
 					<div class="subject">Test Instructions</div>
-						Test instructions, notes and known problems				
+						Test instructions, notes and known problems (transition none)				
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
@@ -19,7 +19,7 @@
 				transitionOptions: {title:'List',target: 'Scrollable1', url: '#Scrollable1'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list One</div>
-					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint	 (transition slide)				
 				</div>				
 			</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
@@ -27,7 +27,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable1P', url: '#Scrollable1P'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list OneP</div>
-						Programmatic creation of WidgetList uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+						Programmatic creation of WidgetList uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint  (transition flip)					
 					</div>				
 				</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
@@ -35,7 +35,7 @@
 				transitionOptions: {title:'List',target: 'Scrollable2', url: '#Scrollable2'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list Two</div>
-					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint  (transition fade)
 				</div>				
 			</li>
 			
@@ -48,27 +48,27 @@
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
-				data-dojo-props="clickable: true, noArrow: true, 
+				data-dojo-props="clickable: true, noArrow: true, transition:'fade',
 				transitionOptions: {title:'List',target: 'Scrollable4', url: '#Scrollable4'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list Four</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer					
+					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
-				data-dojo-props="clickable: true, noArrow: true, 
+				data-dojo-props="clickable: true, noArrow: true, transition:'flip', 
 				transitionOptions: {title:'List',target: 'Scrollable5', url: '#Scrollable5'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list Five</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer				
+					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
 				data-dojo-props="clickable: true, noArrow: true, 
-				transitionOptions: {title:'List',target: 'ListItem-domButtons', url: '#ListItem-domButtons'}">
+				transitionOptions: {title:'List',target: 'ListItemDomButtons', url: '#ListItemDomButtons'}">
 				<div class="textBox">
 					<div class="subject">Dojox Mobile Test</div>
-					A copy of the dojox/mobile test test_ListItem-domButtons, (removed height="auto"), had used it to avoid problem with initially showing this page.					
+					A copy of the dojox/mobile test test_ListItemDomButtons, (removed height="auto"), had used it to avoid problem with initially showing this page.					
 				</div>				
 			</li>
 		</ul>

--- a/tests/scrollableTestApp/views/Scrollable1.js
+++ b/tests/scrollableTestApp/views/Scrollable1.js
@@ -29,6 +29,12 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	setDetailsContext = function(index){
 		repeatmodel.set("cursorId", index);
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){

--- a/tests/scrollableTestApp/views/Scrollable1P.js
+++ b/tests/scrollableTestApp/views/Scrollable1P.js
@@ -34,6 +34,12 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 		repeatmodel.set("cursorIndex", index);
 		
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){

--- a/tests/scrollableTestApp/views/Scrollable2.js
+++ b/tests/scrollableTestApp/views/Scrollable2.js
@@ -25,6 +25,12 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	setDetailsContext = function(index){
 		repeatmodel.set("cursorId", index);
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){

--- a/tests/scrollableTestApp/views/Scrollable3.js
+++ b/tests/scrollableTestApp/views/Scrollable3.js
@@ -25,6 +25,12 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	setDetailsContext = function(index){
 		repeatmodel.set("cursorId", index);
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){

--- a/tests/scrollableTestApp/views/Scrollable4.js
+++ b/tests/scrollableTestApp/views/Scrollable4.js
@@ -25,6 +25,12 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	setDetailsContext = function(index){
 		repeatmodel.set("cursorId", index);
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){

--- a/tests/scrollableTestApp/views/Scrollable5.js
+++ b/tests/scrollableTestApp/views/Scrollable5.js
@@ -25,6 +25,12 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	setDetailsContext = function(index){
 		repeatmodel.set("cursorId", index);
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){

--- a/tests/scrollableTestApp2/config-phone.json
+++ b/tests/scrollableTestApp2/config-phone.json
@@ -76,17 +76,25 @@
 	//the name of the view to load when the app is initialized.
 	"defaultView": "configuration,ScrollableListSelection",
 
-	// these are the possilbe defaultTransitions
+	// these are the possible defaultTransitions, 
+	// the defaultTransition is only used if transition is not set in the config and it is not set or defaulted on the transitionEvent
 	//"defaultTransition": "slide",
 	//"defaultTransition": "none",
 	//"defaultTransition": "fade",
-	"defaultTransition": "flip",     
+	"defaultTransition": "flip",     // Note: flip does not work with a BorderLayout Controller
+
+	// these are the possible transitions, 
+	// if a transition is set on a view or parent it will override the transition set on the transitionEvent or the defaultTransition in the config.
+	//"transition": "slide",
+	//"transition": "none",
+	//"transition": "fade",
+	//"transition": "flip",
 
 	//views are groups of views and models loaded at once
 	"views": {
 		"configuration": {
 			"defaultView": "ScrollableListSelection",
-			"defaultTransition": "slide",
+			"transition": "slide",
 			"definition": "none",
 
 			"views": {
@@ -98,15 +106,19 @@
 
 		
 		"TestInfo": {
+			"transition": "none",
 			"template": "scrollableTestApp/templates/TestInfo.html"
 		},
 		"Scrollable1": {
+			"transition": "slide",
 			"template": "scrollableTestApp/templates/Scrollable1.html"
 		},
 		"Scrollable1P": {
+			"transition": "flip",
 			"template": "scrollableTestApp/templates/Scrollable1P.html"
 		},
 		"Scrollable2": {
+			"transition": "fade",
 			"template": "scrollableTestApp/templates/Scrollable2.html"
 		},
 		"Scrollable3": {
@@ -118,10 +130,12 @@
 		"Scrollable5": {
 			"template": "scrollableTestApp/templates/Scrollable5.html"
 		},
-		"ListItem-domButtons": {
+		"ListItemDomButtons": {
+			"definition": "scrollableTestApp/views/ListItem-domButtons",
 			"template": "scrollableTestApp/templates/ListItem-domButtons.html"
 		},
-		"ListItem-domButtons2": {
+		"ListItemDomButtons2": {
+			"definition": "scrollableTestApp/views/ListItem-domButtons2",
 			"template": "scrollableTestApp/templates/ListItem-domButtons2.html"
 		},
 

--- a/tests/scrollableTestApp2/config-tablet.json
+++ b/tests/scrollableTestApp2/config-tablet.json
@@ -86,17 +86,26 @@
 	"defaultView": "configuration+TestInfo",
 	//"defaultView": "configuration+Scrollable5",
 
-	// these are the possilbe defaultTransitions
-	"defaultTransition": "slide",
+	// these are the possible defaultTransitions, 
+	// the defaultTransition is only used if transition is not set in the config and it is not set or defaulted on the transitionEvent
+	//"defaultTransition": "slide",
 	//"defaultTransition": "none",
 	//"defaultTransition": "fade",
-	//"defaultTransition": "flip",     
+	"defaultTransition": "flip",     // Note: flip does not work with a BorderLayout Controller
+
+	// these are the possible transitions, 
+	// if a transition is set on a view or parent it will override the transition set on the transitionEvent or the defaultTransition in the config.
+	//"transition": "slide",
+	//"transition": "none",
+	//"transition": "fade",
+	//"transition": "flip",
 
 	//views are groups of views and models loaded at once
 	"views": {
 		"navigation": {
 			"template": "scrollableTestApp/templates/tablet/ViewScrollableLists.html",
 			"definition" : "scrollableTestApp/views/tablet/ViewScrollableLists.js",
+			"transition": "slide",
 			"constraint" : "left"
 		},
 		"configuration": {
@@ -119,17 +128,21 @@
 		
 		
 		"TestInfo": {
+			"transition": "none",
 			"template": "scrollableTestApp/templates/TestInfo.html"
 		},
 		"Scrollable1": {
+			"transition": "slide",
 			"template": "scrollableTestApp/templates/Scrollable1.html"
 		},
 		"Scrollable1P": {
 			"template": "scrollableTestApp/templates/Scrollable1P.html",
+			"transition": "flip",
 			"constraint" : "center"
 		},
 		"Scrollable2": {
 			"template": "scrollableTestApp/templates/Scrollable2.html",
+			"transition": "fade",
 			"constraint" : "center"
 		},
 		"Scrollable3": {
@@ -143,18 +156,20 @@
 		"Scrollable5": {
 			"template": "scrollableTestApp/templates/Scrollable5.html"
 		},
-		"ListItem-domButtons": {
+		"ListItemDomButtons": {
+			"definition": "scrollableTestApp/views/ListItem-domButtons",
 			"template": "scrollableTestApp/templates/ListItem-domButtons.html",
 			"constraint" : "center"
 		},
-		"ListItem-domButtons2": {
+		"ListItemDomButtons2": {
+			"definition": "scrollableTestApp/views/ListItem-domButtons2",
 			"template": "scrollableTestApp/templates/ListItem-domButtons2.html",
 			"constraint" : "center"
 		},
 		
 		"repeatDetails": {
 			"template": "scrollableTestApp/templates/repeatDetails.html",
-			"defaultTransition": "slide",
+			"transition": "slide",
 			"constraint" : "center"
 		}
 	}

--- a/tests/scrollableTestApp2/css/tablet.css
+++ b/tests/scrollableTestApp2/css/tablet.css
@@ -77,4 +77,5 @@ div .navPane {
 	width:250px;
 	border-right:1px solid black;
 	background-color: #C5CCD3;
+	z-index:100;
 }

--- a/tests/scrollableTestApp2/src.js
+++ b/tests/scrollableTestApp2/src.js
@@ -13,12 +13,5 @@ require(["dojox/app/main", "dojox/json/ref"],
 		var config = json.fromJson(configJson);
 		config.isTablet = isTablet;
 		Application(config);
-			 	
-	 	window.removeScrollableItem = function(index){
-				var repeatmodel = app.loadedModels.repeatmodels;
-				repeatmodel.model.splice(index, 1);
-				return false; 	 		
-	 	};
-
 	});
 });

--- a/tests/scrollableTestApp2/templates/ListItem-domButtons.html
+++ b/tests/scrollableTestApp2/templates/ListItem-domButtons.html
@@ -18,85 +18,85 @@
 		</div>
 
 		<ul data-dojo-type="dojox.mobile.RoundRectList">
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 1
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 2
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 3
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 4
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 5
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 6
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 7
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 8
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 9
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 10
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 11
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 12
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 13
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 14
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 15
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 16
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 17
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 18
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 19
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 20
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 21
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 22
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 23
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 24
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 25
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 26
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItem-domButtons2", url: "#ListItem-domButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 27
 			</li>
 		</ul>

--- a/tests/scrollableTestApp2/templates/configuration/ScrollableListSelection.html
+++ b/tests/scrollableTestApp2/templates/configuration/ScrollableListSelection.html
@@ -12,7 +12,7 @@
 					transitionOptions: {title:'List',target: 'TestInfo', url: '#TestInfo'}">
 					<div class="textBox">
 						<div class="subject">Test Instructions</div>
-						Test instructions, notes and known problems				
+						Test instructions, notes and known problems (transition none)				
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
@@ -20,7 +20,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable1', url: '#Scrollable1'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list One</div>
-						Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint	 (transition slide)				
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
@@ -28,7 +28,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable1P', url: '#Scrollable1P'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list OneP</div>
-						Programmatic creation of WidgetList uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+						Programmatic creation of WidgetList uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint  (transition flip)					
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
@@ -36,7 +36,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable2', url: '#Scrollable2'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list Two</div>
-						Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint  (transition fade)
 					</div>				
 				</li>
 			
@@ -49,30 +49,29 @@
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
-					data-dojo-props="clickable: true, noArrow: true, 
+				data-dojo-props="clickable: true, noArrow: true, transition:'fade',
 					transitionOptions: {title:'List',target: 'Scrollable4', url: '#Scrollable4'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list Four</div>
-						Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer					
+					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
-					data-dojo-props="clickable: true, noArrow: true, 
+				data-dojo-props="clickable: true, noArrow: true, transition:'flip', 
 					transitionOptions: {title:'List',target: 'Scrollable5', url: '#Scrollable5'}">
 					<div class="textBox">
 					<div class="subject">Scrollable list Five</div>
-						Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer					
+					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
 					data-dojo-props="clickable: true, noArrow: true, 
-					transitionOptions: {title:'List',target: 'ListItem-domButtons', url: '#ListItem-domButtons'}">
+					transitionOptions: {title:'List',target: 'ListItemDomButtons', url: '#ListItemDomButtons'}">
 					<div class="textBox">
 						<div class="subject">Dojox Mobile Test</div>
-						A copy of the dojox/mobile test test_ListItem-domButtons, (removed height="auto"), had used it to avoid problem with initially showing this page.					
+						A copy of the dojox/mobile test test_ListItemDomButtons, (removed height="auto"), had used it to avoid problem with initially showing this page.					
 					</div>				
 				</li>
 			</ul>
 		</div>
 	</div>
-</div>

--- a/tests/scrollableTestApp2/templates/tablet/ViewScrollableLists.html
+++ b/tests/scrollableTestApp2/templates/tablet/ViewScrollableLists.html
@@ -11,7 +11,7 @@
 				transitionOptions: {title:'List',target: 'TestInfo', url: '#TestInfo'}">
 				<div class="textBox">
 					<div class="subject">Test Instructions</div>
-						Test instructions, notes and known problems				
+						Test instructions, notes and known problems (transition none)				
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
@@ -19,7 +19,7 @@
 				transitionOptions: {title:'List',target: 'Scrollable1', url: '#Scrollable1'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list One</div>
-					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint	 (transition slide)				
 				</div>				
 			</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
@@ -27,7 +27,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable1P', url: '#Scrollable1P'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list OneP</div>
-						Programmatic creation of WidgetList uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+						Programmatic creation of WidgetList uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint  (transition flip)					
 					</div>				
 				</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
@@ -35,7 +35,7 @@
 				transitionOptions: {title:'List',target: 'Scrollable2', url: '#Scrollable2'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list Two</div>
-					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint					
+					Uses app/widgets/Container with a fixed Header and a fixed Footer both with data-app-constraint  (transition fade)
 				</div>				
 			</li>
 			
@@ -48,27 +48,27 @@
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
-				data-dojo-props="clickable: true, noArrow: true, 
+				data-dojo-props="clickable: true, noArrow: true, transition:'fade',
 				transitionOptions: {title:'List',target: 'Scrollable4', url: '#Scrollable4'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list Four</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer					
+					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
-				data-dojo-props="clickable: true, noArrow: true, 
+				data-dojo-props="clickable: true, noArrow: true, transition:'flip', 
 				transitionOptions: {title:'List',target: 'Scrollable5', url: '#Scrollable5'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list Five</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer				
+					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
 				data-dojo-props="clickable: true, noArrow: true, 
-				transitionOptions: {title:'List',target: 'ListItem-domButtons', url: '#ListItem-domButtons'}">
+				transitionOptions: {title:'List',target: 'ListItemDomButtons', url: '#ListItemDomButtons'}">
 				<div class="textBox">
 					<div class="subject">Dojox Mobile Test</div>
-					A copy of the dojox/mobile test test_ListItem-domButtons, (removed height="auto"), had used it to avoid problem with initially showing this page.					
+					A copy of the dojox/mobile test test_ListItemDomButtons, (removed height="auto"), had used it to avoid problem with initially showing this page.					
 				</div>				
 			</li>
 		</ul>

--- a/tests/scrollableTestApp2/views/Scrollable1.js
+++ b/tests/scrollableTestApp2/views/Scrollable1.js
@@ -29,6 +29,12 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	setDetailsContext = function(index){
 		repeatmodel.set("cursorId", index);
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){
@@ -64,7 +70,7 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 
 	return {
 		// repeate view init
-		init: function(){			
+		init: function(){
 			app = this.app;
 
 			repeatmodel = this.loadedModels.repeatmodels;

--- a/tests/scrollableTestApp2/views/Scrollable1P.js
+++ b/tests/scrollableTestApp2/views/Scrollable1P.js
@@ -34,6 +34,12 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 		repeatmodel.set("cursorIndex", index);
 		
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){

--- a/tests/scrollableTestApp2/views/Scrollable2.js
+++ b/tests/scrollableTestApp2/views/Scrollable2.js
@@ -25,6 +25,12 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	setDetailsContext = function(index){
 		repeatmodel.set("cursorId", index);
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){

--- a/tests/scrollableTestApp2/views/Scrollable3.js
+++ b/tests/scrollableTestApp2/views/Scrollable3.js
@@ -25,6 +25,12 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	setDetailsContext = function(index){
 		repeatmodel.set("cursorId", index);
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){

--- a/tests/scrollableTestApp2/views/Scrollable4.js
+++ b/tests/scrollableTestApp2/views/Scrollable4.js
@@ -25,6 +25,12 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	setDetailsContext = function(index){
 		repeatmodel.set("cursorId", index);
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){

--- a/tests/scrollableTestApp2/views/Scrollable5.js
+++ b/tests/scrollableTestApp2/views/Scrollable5.js
@@ -25,6 +25,12 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	setDetailsContext = function(index){
 		repeatmodel.set("cursorId", index);
 	};
+	
+	removeScrollableItem = function(index){
+				var repeatmodel = app.loadedModels.repeatmodels;
+				repeatmodel.model.splice(index, 1);
+				return false; 	 		
+	};
 
 	// insert an item
 	var insertResult = function(index, e){


### PR DESCRIPTION
Update the layout support to take a "-" to indicate that a view should be removed (or hidden) in addition to the + used to indicate multiple views will be displayed.  Tests have also been updated to test this support.  Note that after this change a "-" can no longer be used in a view name in the config.

The way defaultTransition was working has also been updated to allow a transition set on a transition event to take precedence over the defaultTransition set in the config. But there are cases where an app would like to override the transitions via the config, so I have added another config option "transition" which will take precedence over the transition set on the event.
