### PR TITLE
Create parameters to be passed in View livecycle (xxx(De)Activate) methods.

### DIFF
--- a/controllers/Transition.js
+++ b/controllers/Transition.js
@@ -326,7 +326,7 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 					// if we are on IE CSS3 transitions are not supported (yet). So just skip the transition itself.
 					// we also skip in we are transitioning to a nested view from a parent view and that nested view
 					// did not have any current
-					var mergedOpts = lang.mixin({}, data); // handle reverse from mergedOpts or transitionDir
+					var mergedOpts = lang.mixin({}, opts); // handle reverse from mergedOpts or transitionDir
 					mergedOpts = lang.mixin({}, mergedOpts, {
 						reverse: (mergedOpts.reverse || mergedOpts.transitionDir===-1)?true:false,
 						// if transition is set for the view (or parent) in the config use it, otherwise use it from the event or defaultTransition from the config

--- a/tests/globalizedApp/config.json
+++ b/tests/globalizedApp/config.json
@@ -32,6 +32,10 @@
 				"dojox/mobile/RoundRectList",
 				"dojox/mobile/ListItem"
 			]
+		},
+		"detail": {
+			"definition" : "globalizedApp/detail",
+			"template": "globalizedApp/detail.html"
 		}
 	}
 }

--- a/tests/globalizedApp/detail.html
+++ b/tests/globalizedApp/detail.html
@@ -1,0 +1,3 @@
+<div class="view mblView">
+	<span id="label"></span>
+</div>

--- a/tests/globalizedApp/detail.js
+++ b/tests/globalizedApp/detail.js
@@ -1,7 +1,7 @@
 define(["dojo/dom"], function(dom){
 	return {
-		beforeActivate: function(view, data){
-			dom.byId("label").innerHTML = this.nls[view.name]+(data?("-"+data):"");
+		beforeActivate: function(previousView, data){
+			dom.byId("label").innerHTML = this.nls[previousView.name]+(data?("-"+data):"");
 
 		}
 	}

--- a/tests/globalizedApp/detail.js
+++ b/tests/globalizedApp/detail.js
@@ -1,0 +1,8 @@
+define(["dojo/dom"], function(dom){
+	return {
+		beforeActivate: function(view, data){
+			dom.byId("label").innerHTML = this.nls[view.name]+(data?("-"+data):"");
+
+		}
+	}
+})

--- a/tests/globalizedApp/home.html
+++ b/tests/globalizedApp/home.html
@@ -1,10 +1,10 @@
 <div class="view mblView">
     <ul data-dojo-type="dojox/mobile/RoundRectList">
-		<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props="'clickable':true, 'label': '${nls.label0}'">
+		<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props="'clickable':true, 'label': '${nls.label0}', target: 'detail'">
   		</li>
-        <li data-dojo-type="dojox/mobile/ListItem" data-dojo-props="'clickable':true, 'label': '${nls.label1}'">
+        <li data-dojo-type="dojox/mobile/ListItem" data-dojo-props="'clickable':true, 'label': '${nls.label1}', target: 'detail'">
         </li>
-        <li data-dojo-type="dojox/mobile/ListItem" data-dojo-props="'clickable':true">
+        <li data-dojo-type="dojox/mobile/ListItem" data-dojo-props="'clickable':true, target: 'detail', transitionOptions: { data: 'foo' }">
 			${nls.label2}
         </li>
     </ul>

--- a/tests/globalizedApp/nls/app.js
+++ b/tests/globalizedApp/nls/app.js
@@ -1,7 +1,7 @@
 define({
-  root: {
-	home: "Home",
-   	label0: "Label Zero"
-  },
-  fr: true
+	root: {
+	  home: "Home",
+	  label0: "Label Zero"
+	},
+	fr: true
 });

--- a/tests/globalizedApp/nls/home.js
+++ b/tests/globalizedApp/nls/home.js
@@ -1,7 +1,7 @@
 define({
-  root: {
-   	label1: "Label One",
-	label2: "Label Two"
-  },
-  fr: true
+	root: {
+		label1: "Label One",
+		label2: "Label Two"
+	},
+	fr: true
 });


### PR DESCRIPTION
livecycle methods are now called with two parameters:
1. The reference to the previous view at the same layout constraint (for activate methods) or the refence to the next view at the same layout constraint (for deactivate methods)
2. a raw data object that can be set in the TranstionEvent options with a data property.

This fixes #146 and #147.
