### PR TITLE
Updates to transition controller, main, widgets/Container and widgets/_ScrollableMixin and many of the tests

### DIFF
--- a/controllers/Transition.js
+++ b/controllers/Transition.js
@@ -276,7 +276,11 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 			}
 
 			if(removeView){
-				// if we remove a view with not replacement
+				if(next !== current){ // nothing to remove
+					this.app.log("> in Transition._doTransition called with removeView true, but that view is not available to remove");
+					return;  // trying to remove a view which is not showing
+				}	
+				// if next == current we will set next to null and remove the view with out a replacement
 				next = null;
 			}
 
@@ -322,9 +326,9 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 				}
 				
 				var result = true;
-				if(transit && (!has("ie") || has("ie") >= 10) && (!nested || current != null)){
-					// if we are on IE CSS3 transitions are not supported (yet). So just skip the transition itself.
-					// we also skip in we are transitioning to a nested view from a parent view and that nested view
+				if(transit && (!nested || current != null)){
+					// css3 transit has the check for IE so it will not try to do it on ie, so we do not need to check it here.
+					// We skip in we are transitioning to a nested view from a parent view and that nested view
 					// did not have any current
 					var mergedOpts = lang.mixin({}, opts); // handle reverse from mergedOpts or transitionDir
 					mergedOpts = lang.mixin({}, mergedOpts, {

--- a/main.js
+++ b/main.js
@@ -48,6 +48,7 @@ define(["require", "dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare",
 						try{
 							var storeCtor = require(type);
 						}catch(e){
+							console.error(type+" must be listed in the dependencies");
 							throw new Error(type+" must be listed in the dependencies");
 						}
 						if(config.data && lang.isString(config.data)){
@@ -57,7 +58,17 @@ define(["require", "dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare",
 							//and will cause infinitive loop when creating StatefulModel.
 							config.data = lang.getObject(config.data);
 						}
-						params.stores[item].store = new storeCtor(config);
+						if(params.stores[item].observable){
+							try{
+								var observableCtor = require("dojo/store/Observable");
+							}catch(e){
+								console.error("dojo/store/Observable must be listed in the dependencies");
+								throw new Error("dojo/store/Observable must be listed in the dependencies");
+							}
+							params.stores[item].store = observableCtor(new storeCtor(config));							
+						}else{
+							params.stores[item].store = new storeCtor(config);
+						}
 					}
 				}
 			}
@@ -342,6 +353,7 @@ define(["require", "dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare",
 
 	return function(config, node){
 		if(!config){
+			console.error("App Config Missing");
 			throw new Error("App Config Missing");
 		}
 

--- a/tests/borderLayoutApp/navigation.html
+++ b/tests/borderLayoutApp/navigation.html
@@ -22,52 +22,52 @@
 		</script>
 	</head>
 	<body style="width:100%; height:350px">
-		<div dojoType="dojox.app.widgets.Container" style="width:100%; height:100%">
+		<div dojoType="dojox/app/widgets/Container" style="width:100%; height:100%">
 			<!-- left -->
-			<div dojoType="dojox.app.widgets.Container" style="width:240px;" data-app-constraint="left">
-				<h1 data-app-constraint="top" dojoType="dojox.mobile.Heading">Layout App</h1>
-				<div data-dojo-type="dojox.app.widgets.Container" data-app-constraint="center" scrollable="true">
-					<h2 dojoType="dojox.mobile.EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Navigation</h2>
-					<ul data-dojo-type="dojox.mobile.RoundRectList" data-app-constraint="center">
-						<li dojoType="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'simple',target:'simple',url:'#simple'}">
+			<div dojoType="dojox/app/widgets/Container" style="width:240px;" data-app-constraint="left">
+				<h1 data-app-constraint="top" dojoType="dojox/mobile/Heading">Layout App</h1>
+				<div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" scrollable="true">
+					<h2 dojoType="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Navigation</h2>
+					<ul data-dojo-type="dojox/mobile/RoundRectList" data-app-constraint="center">
+						<li dojoType="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'simple',target:'simple',url:'#simple'}">
 							Simple Data Binding
 						</li>
-						<li dojoType="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'repeat',target:'repeat',url:'#repeat'}">
+						<li dojoType="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'repeat',target:'repeat',url:'#repeat'}">
 							Repeat Data Binding
 						</li>
-						<li dojoType="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'generate',target:'generate',url:'#generate'}">
+						<li dojoType="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'generate',target:'generate',url:'#generate'}">
 							Simple Form Generate
 						</li>
 					</ul>
-					<h2 dojoType="dojox.mobile.EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="bottom">bottom</h2>
+					<h2 dojoType="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="bottom">bottom</h2>
 				</div>
-				<h1 data-app-constraint="bottom" dojoType="dojox.mobile.Heading">footer</h1>
+				<h1 data-app-constraint="bottom" dojoType="dojox/mobile/Heading">footer</h1>
 			</div>
 			
 			<!-- top -->
-			<div dojoType="dojox.app.widgets.Container" style="height:50px; background-color:red" data-app-constraint="top">
-				<h1 data-app-constraint="top" dojoType="dojox.mobile.Heading">Top</h1>
+			<div dojoType="dojox/app/widgets/Container" style="height:50px; background-color:red" data-app-constraint="top">
+				<h1 data-app-constraint="top" dojoType="dojox/mobile/Heading">Top</h1>
 			</div>
 			
 			<!-- center -->
-			<div dojoType="dojox.app.widgets.Container" style="height:300px; width:100%; background-color:blue" data-app-constraint="top">
+			<div dojoType="dojox/app/widgets/Container" style="height:300px; width:100%; background-color:blue" data-app-constraint="top">
 				<!-- left -->
-				<div dojoType="dojox.app.widgets.Container" style="width:240px;" data-app-constraint="left">
-					<h1 data-app-constraint="top" dojoType="dojox.mobile.Heading">Layout App</h1>
-					<div data-dojo-type="dojox.app.widgets.Container" data-app-constraint="center" scrollable="true">
-						<h2 dojoType="dojox.mobile.EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Navigation</h2>
-						<ul data-dojo-type="dojox.mobile.RoundRectList" data-app-constraint="center">
-							<li dojoType="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'simple',target:'simple',url:'#simple'}">
+				<div dojoType="dojox/app/widgets/Container" style="width:240px;" data-app-constraint="left">
+					<h1 data-app-constraint="top" dojoType="dojox/mobile/Heading">Layout App</h1>
+					<div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" scrollable="true">
+						<h2 dojoType="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Navigation</h2>
+						<ul data-dojo-type="dojox/mobile/RoundRectList" data-app-constraint="center">
+							<li dojoType="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'simple',target:'simple',url:'#simple'}">
 								Simple Data Binding
 							</li>
-							<li dojoType="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'repeat',target:'repeat',url:'#repeat'}">
+							<li dojoType="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'repeat',target:'repeat',url:'#repeat'}">
 								Repeat Data Binding
 							</li>
-							<li dojoType="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'generate',target:'generate',url:'#generate'}">
+							<li dojoType="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'generate',target:'generate',url:'#generate'}">
 								Simple Form Generate
 							</li>
 						</ul>
-						<h2 dojoType="dojox.mobile.EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="bottom">bottom</h2>
+						<h2 dojoType="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="bottom">bottom</h2>
 					</div>
 				</div>
 			</div>

--- a/tests/borderLayoutApp/templates/generate.html
+++ b/tests/borderLayoutApp/templates/generate.html
@@ -1,5 +1,5 @@
 <div class="view mblView"  data-app-constraint="center">
-    <h1 data-dojo-type="dojox.mobile.Heading" data-app-constraint="center" >generate test</h1>
+    <h1 data-dojo-type="dojox/mobile/Heading" data-app-constraint="center" >generate test</h1>
     <div>This is generate data line 1</div>
     <div>This is generate data line 2</div>
     <div>This is generate data line 3</div>

--- a/tests/borderLayoutApp/templates/generateBACK.html
+++ b/tests/borderLayoutApp/templates/generateBACK.html
@@ -1,12 +1,12 @@
 <div id="generate" class="view mblView"  data-app-constraint="center">
-	<h1 data-dojo-type="dojox.mobile.Heading" data-app-constraint="top">Simple Form Generate Example</h1>
-	<div data-dojo-type="dojox.app.widgets.Container" data-dojo-props="scrollable:true" data-app-constraint="center">
+	<h1 data-dojo-type="dojox/mobile/Heading" data-app-constraint="top">Simple Form Generate Example</h1>
+	<div data-dojo-type="dojox/app/widgets/Container" data-dojo-props="scrollable:true" data-app-constraint="center">
 		<div id="main">
 			<div id="mainContent" class="generate-maincontent">
 				<div id="outerModelArea">
-					<h3 data-dojo-type="dojox.mobile.RoundRectCategory">Model</h3>
+					<h3 data-dojo-type="dojox/mobile/RoundRectCategory">Model</h3>
 					<div class="generate-textarea-row">
-						<textarea class="generate-textarea-cell" data-dojo-type="dojox.mobile.TextArea" id="modelArea" style="width: 300px; height: 300px;">
+						<textarea class="generate-textarea-cell" data-dojo-type="dojox/mobile/TextArea" id="modelArea" style="width: 300px; height: 300px;">
 {
     "Serial": "11111",
     "First": "John",
@@ -24,19 +24,19 @@
 						</textarea>
 					</div>
 					<div class="fieldset">
-						<button id="generate1" data-dojo-type="dojox.mobile.Button" class="mblBlueButton">
+						<button id="generate1" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
 							Generate Form
 						</button>
 					</div>
 				</div>
 				<div id="viewArea" style="display:none">
-					<h3 data-dojo-type="dojox.mobile.RoundRectCategory">Generated View</h3>
+					<h3 data-dojo-type="dojox/mobile/RoundRectCategory">Generated View</h3>
 					<div class="fieldset">
-						<div id="view" data-dojo-type="dojox.mvc.Generate">
+						<div id="view" data-dojo-type="dojox/mvc/Generate">
 						</div>
 					</div>
 					<div class="fieldset">
-						<button id="updateModel" data-dojo-type="dojox.mobile.Button" class="mblBlueButton">
+						<button id="updateModel" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
 							Update Model
 						</button>
 					</div>

--- a/tests/borderLayoutApp/templates/navigation.html
+++ b/tests/borderLayoutApp/templates/navigation.html
@@ -2,48 +2,48 @@
 <!--<div data-dojo-props='id:"border1-left", style:"background-color: #acb386; border: 10px green solid; width: 100px;",
 		splitter:true, minSize:150, maxSize:250'> -->
 	<!-- left from templates -->
-	<div data-dojo-type="dojox.app.widgets.Container" class="navPane" region="leading"  style="width: 250px;", data-app-constraint="left">
-		<!-- <h1 data-dojo-type="dojox.mobile.Heading"  data-app-constraint="left">Layout App</h1> -->
+	<div data-dojo-type="dojox/app/widgets/Container" class="navPane" region="leading"  style="width: 250px;", data-app-constraint="left">
+		<!-- <h1 data-dojo-type="dojox/mobile/Heading"  data-app-constraint="left">Layout App</h1> -->
 		<div>
-			<!-- <h2 data-dojo-type="dojox.mobile.EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Navigation</h2> -->
-			<ul data-dojo-type="dojox.mobile.RoundRectList" data-app-constraint="center">
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1',url:'#view1'}">
+			<!-- <h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Navigation</h2> -->
+			<ul data-dojo-type="dojox/mobile/RoundRectList" data-app-constraint="center">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1',url:'#view1'}">
 					View 1 top
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view2',target:'view2',url:'#view2'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view2',target:'view2',url:'#view2'}">
 					View 2 top
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view3',target:'view3',url:'#view3'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view3',target:'view3',url:'#view3'}">
 					View 3 left
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
 					View 4 left
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view5',target:'view5',url:'#view5'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view5',target:'view5',url:'#view5'}">
 					View 5 center
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view6',target:'view6',url:'#view6'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view6',target:'view6',url:'#view6'}">
 					View 6 center
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view7',target:'view7',url:'#view7'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view7',target:'view7',url:'#view7'}">
 					View 7 right
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view8',target:'view8',url:'#view8'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view8',target:'view8',url:'#view8'}">
 					View 8 right
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view9',target:'view9',url:'#view9'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view9',target:'view9',url:'#view9'}">
 					View 9 bottom
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view10',target:'view10',url:'#view10'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view10',target:'view10',url:'#view10'}">
 					View 10 bottom
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'simple',target:'simple',url:'#simple'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'simple',target:'simple',url:'#simple'}">
 					Simple Data Binding
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'repeat',target:'repeat',url:'#repeat'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'repeat',target:'repeat',url:'#repeat'}">
 					Repeat Data Binding
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'generate',target:'generate',url:'#generate'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'generate',target:'generate',url:'#generate'}">
 					Simple Form Generate
 				</li>
 			</ul>

--- a/tests/borderLayoutApp/templates/repeat.html
+++ b/tests/borderLayoutApp/templates/repeat.html
@@ -1,12 +1,12 @@
 <div class="view mblView"  data-app-constraint="center">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
-    <h1 data-dojo-type="dojox.mobile.Heading" data-app-constraint="center">Repeat Data Binding Example</h1>
+    <h1 data-dojo-type="dojox/mobile/Heading" data-app-constraint="center">Repeat Data Binding Example</h1>
     <form name="repeatTestForm" id="repeatTestForm">    
     	<div class="field-title">Search Results</div>
         <div id="repeatWidget" class="fieldset" data-dojo-type="dojox/mvc/Repeat" 
         	data-dojo-props="exprchar: '#', children: this.loadedModels.repeatmodels.model" >
            <div class="row">            
-                    <input data-dojo-type="dojox.mobile.TextBox"
+                    <input data-dojo-type="dojox/mobile/TextBox"
                         id="nameInput#{this.index}" data-dojo-props="value: at('rel:#{this.index}','First')" placeHolder="First Name"></input>
                     <button type="button" id="detail#{this.index}" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
                         Details

--- a/tests/borderLayoutApp/templates/repeatDetails.html
+++ b/tests/borderLayoutApp/templates/repeatDetails.html
@@ -1,6 +1,6 @@
 <div class="view mblView"  data-app-constraint="center">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
-    <h1 data-dojo-type="dojox.mobile.Heading" back="Back">Repeat Details</h1>
+    <h1 data-dojo-type="dojox/mobile/Heading" back="Back">Repeat Details</h1>
     <form name="repeatTestForm" id="repeatTestForm">    
 		<div data-dojo-type="dojox/mvc/Group" 
 			data-dojo-props="target: at(this.loadedModels.repeatmodels, 'cursor')">
@@ -14,14 +14,14 @@
 						<tr>
 							<td style="width: 100px;" class="layout">First Name</td>
 							<td class="layout">							
-								<input  id="firstInput" data-dojo-type="dojox.mobile.TextBox" 
+								<input  id="firstInput" data-dojo-type="dojox/mobile/TextBox" 
 									data-dojo-props="value: at('rel:', 'First'), placeholder:'First Name'">
 							</td>
 						</tr>
 						<tr>
 							<td style="width: 100px;" class="layout">Last Name</td>
 							<td class="layout">
-								<input id="lastInput" data-dojo-type="dojox.mobile.TextBox"
+								<input id="lastInput" data-dojo-type="dojox/mobile/TextBox"
 									 
 									data-dojo-props="placeholder:'Last Name', value: at('rel:', 'Last')">
 							</td>
@@ -29,14 +29,14 @@
 						<tr>
 							<td style="width: 100px;" class="layout">Email</td>
 							<td class="layout">
-								<input  id="emailInput2" data-dojo-type="dojox.mobile.TextBox"
+								<input  id="emailInput2" data-dojo-type="dojox/mobile/TextBox"
 									data-dojo-props="value: at('rel:', 'Email'), placeholder:'Email'">
 							</td>
 						</tr>
 						<tr>
 							<td style="width: 100px;" class="layout">Telephone</td>
 							<td class="layout">
-								<input  id="telInput" data-dojo-type="dojox.mobile.TextBox"
+								<input  id="telInput" data-dojo-type="dojox/mobile/TextBox"
 									data-dojo-props="value: at('rel:', 'Tel'), placeholder:'Telephone'">
 							</td>
 						</tr>

--- a/tests/borderLayoutApp/templates/simpleBACK.html
+++ b/tests/borderLayoutApp/templates/simpleBACK.html
@@ -1,7 +1,7 @@
 <div id="settings" class="view mblView" data-app-constraint="center">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
-	<h1 data-dojo-type="dojox.mobile.Heading" data-app-constraint="top">Data Binding Example</h1>
-	<div data-dojo-type="dojox.app.widgets.Container" data-app-constraint="center" data-dojo-props="scrollable:'true'">
+	<h1 data-dojo-type="dojox/mobile/Heading" data-app-constraint="top">Data Binding Example</h1>
+	<div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" data-dojo-props="scrollable:'true'">
 		<form name="testForm" id="testForm">
 			<div class="field-title">
 				Ship to - Bill to Address
@@ -14,7 +14,7 @@
 								First
 							</td>
 							<td class="layout">
-								<input id="firstInput1" data-dojo-type="dojox.mobile.TextBox" data-dojo-props="value: at('rel:', 'First'), placeholder:'First'">
+								<input id="firstInput1" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'First'), placeholder:'First'">
 							</td>
 						</tr>
 						<tr>
@@ -22,7 +22,7 @@
 								Last Name
 							</td>
 							<td class="layout">
-								<input id="lastInput1" data-dojo-type="dojox.mobile.TextBox" data-dojo-props="placeholder:'Last Name', value: at('rel:', 'Last')">
+								<input id="lastInput1" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="placeholder:'Last Name', value: at('rel:', 'Last')">
 							</td>
 						</tr>
 						<tr>
@@ -30,16 +30,16 @@
 								Email
 							</td>
 							<td class="layout">
-								<input id="emailInput1" data-dojo-type="dojox.mobile.TextBox" data-dojo-props="value: at('rel:', 'Email'), placeholder:'Email'">
+								<input id="emailInput1" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'Email'), placeholder:'Email'">
 							</td>
 						</tr>
 					</table>
 					<div class="spacer">
 					</div>
-					<button id="shipto" type="button" data-dojo-type="dojox.mobile.Button" class="mblBlueButton">
+					<button id="shipto" type="button" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
 						Ship To
 					</button>
-					<button id="billto" type="button" data-dojo-type="dojox.mobile.Button" class="mblBlueButton">
+					<button id="billto" type="button" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
 						Bill To
 					</button>
 					<br/>
@@ -50,7 +50,7 @@
 									Street
 								</td>
 								<td class="layout">
-									<input id="streetInput" data-dojo-type="dojox.mobile.TextBox" data-dojo-props="value: at('rel:', 'Street'), placeholder:'Street'">
+									<input id="streetInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'Street'), placeholder:'Street'">
 								</td>
 							</tr>
 							<tr>
@@ -58,7 +58,7 @@
 									City
 								</td>
 								<td class="layout">
-									<input id="cityInput" data-dojo-type="dojox.mobile.TextBox" data-dojo-props="placeholder:'City', value: at('rel:', 'City')">
+									<input id="cityInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="placeholder:'City', value: at('rel:', 'City')">
 								</td>
 							</tr>
 							<tr>
@@ -66,7 +66,7 @@
 									State
 								</td>
 								<td class="layout">
-									<input id="StateInput" data-dojo-type="dojox.mobile.TextBox" data-dojo-props="value: at('rel:', 'State'), placeholder:'State'">
+									<input id="StateInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'State'), placeholder:'State'">
 								</td>
 							</tr>
 							<tr>
@@ -74,7 +74,7 @@
 									State
 								</td>
 								<td class="layout">
-									<input id="ZipInput" data-dojo-type="dojox.mobile.TextBox" data-dojo-props="value: at('rel:', 'Zip'), placeholder:'Zip Code'">
+									<input id="ZipInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'Zip'), placeholder:'Zip Code'">
 								</td>
 							</tr>
 						</table>
@@ -83,7 +83,7 @@
 			</div>
 			<div class="spacer">
 			</div>
-			<button id="reset1" type="button" data-dojo-type="dojox.mobile.Button" class="mblBlueButton">
+			<button id="reset1" type="button" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
 				Reset
 			</button>
 		</form>

--- a/tests/borderLayoutApp/templates/view3.html
+++ b/tests/borderLayoutApp/templates/view3.html
@@ -1,50 +1,50 @@
 <div style='background-color:cyan;'>
     <h3 style='background-color:cyan;'>View 3 left......................</h3>
-	<div data-dojo-type="dojox.mobile.ScrollableView">    
-			<ul data-dojo-type="dojox.mobile.RoundRectList">
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'otherSet',target:'view2+view10+view4+view8+view6',url:'#view2+view10+view4+view8+view6'}">
+	<div data-dojo-type="dojox/mobile/ScrollableView">    
+			<ul data-dojo-type="dojox/mobile/RoundRectList">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'otherSet',target:'view2+view10+view4+view8+view6',url:'#view2+view10+view4+view8+view6'}">
 					View 2+10+4+8+6'
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'originalSet',target:'view1+view9+view3+view7+view5',url:'#view1+view9+view3+view7+view5'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'originalSet',target:'view1+view9+view3+view7+view5',url:'#view1+view9+view3+view7+view5'}">
 					View 1+9+3+7+5'
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1-view8',url:'#view1-view8'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1-view8',url:'#view1-view8'}">
 					View top 1-8 
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view2-view7',target:'view2-view7',url:'#view2-view7'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view2-view7',target:'view2-view7',url:'#view2-view7'}">
 					View 2-7 top
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view3-view9',target:'view3-view9',url:'#view3-view9'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view3-view9',target:'view3-view9',url:'#view3-view9'}">
 					View left 3-9
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
 					View 4 left
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view5-view10',target:'view5-view10',url:'#view5-view10'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view5-view10',target:'view5-view10',url:'#view5-view10'}">
 					View cneter 5-10 
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view6-view10',target:'view6-view10',url:'#view6-view10'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view6-view10',target:'view6-view10',url:'#view6-view10'}">
 					View center 6-10 
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view7',target:'view7',url:'#view7'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view7',target:'view7',url:'#view7'}">
 					View 7 right
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view8',target:'view8',url:'#view8'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view8',target:'view8',url:'#view8'}">
 					View 8 right
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view9',target:'view9',url:'#view9'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view9',target:'view9',url:'#view9'}">
 					View 9 bottom
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view10',target:'view10',url:'#view10'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view10',target:'view10',url:'#view10'}">
 					View 10 bottom
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'simple',target:'simple',url:'#simple'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'simple',target:'simple',url:'#simple'}">
 					Simple Data Binding
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'repeat',target:'repeat',url:'#repeat'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'repeat',target:'repeat',url:'#repeat'}">
 					Repeat Data Binding
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'generate',target:'generate',url:'#generate'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'generate',target:'generate',url:'#generate'}">
 					Simple Form Generate
 				</li>
 			</ul>

--- a/tests/borderLayoutApp/templates/view4.html
+++ b/tests/borderLayoutApp/templates/view4.html
@@ -1,41 +1,41 @@
 <div style='background-color:green;'>
     <h3>View 4 left..added for spacing..</h3>
-	<div data-dojo-type="dojox.mobile.ScrollableView">    
-			<ul data-dojo-type="dojox.mobile.RoundRectList">
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'otherSet',target:'view2+view10+view4+view8+view6',url:'#view2+view10+view4+view8+view6'}">
+	<div data-dojo-type="dojox/mobile/ScrollableView">    
+			<ul data-dojo-type="dojox/mobile/RoundRectList">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'otherSet',target:'view2+view10+view4+view8+view6',url:'#view2+view10+view4+view8+view6'}">
 					View 2+10+4+8+6'
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'originalSet',target:'view1+view9+view3+view7+view5',url:'#view1+view9+view3+view7+view5'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'originalSet',target:'view1+view9+view3+view7+view5',url:'#view1+view9+view3+view7+view5'}">
 					View 1+9+3+7+5'
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1-view8',url:'#view1-view8'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1-view8',url:'#view1-view8'}">
 					View 1-8 top
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view2-view7',target:'view2-view7',url:'#view2-view7'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view2-view7',target:'view2-view7',url:'#view2-view7'}">
 					View 2-7 top
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view3-view9',target:'view3-view9',url:'#view3-view9'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view3-view9',target:'view3-view9',url:'#view3-view9'}">
 					View left 3-9
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
 					View 4 left
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view5-view10',target:'view5-view10',url:'#view5-view10'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view5-view10',target:'view5-view10',url:'#view5-view10'}">
 					View center 5-10 
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view6-view10',target:'view6-view10',url:'#view6-view10'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view6-view10',target:'view6-view10',url:'#view6-view10'}">
 					View center 6-10 
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view7',target:'view7',url:'#view7'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view7',target:'view7',url:'#view7'}">
 					View 7 right
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view8',target:'view8',url:'#view8'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view8',target:'view8',url:'#view8'}">
 					View 8 right
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view9',target:'view9',url:'#view9'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view9',target:'view9',url:'#view9'}">
 					View 9 bottom
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view10',target:'view10',url:'#view10'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view10',target:'view10',url:'#view10'}">
 					View 10 bottom
 				</li>
 				

--- a/tests/borderLayoutApp/templates/view5.html
+++ b/tests/borderLayoutApp/templates/view5.html
@@ -4,17 +4,17 @@
     <h3 style='background-color:blue;'>View 5 center.</h3>
     <h3 style='background-color:blue;'>View 5 center.</h3>
     <h3 style='background-color:blue;'>View 5 center.</h3>
-			<ul data-dojo-type="dojox.mobile.RoundRectList">
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1',url:'#view1'}">
+			<ul data-dojo-type="dojox/mobile/RoundRectList">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view1',target:'view1',url:'#view1'}">
 					View 1 top
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view2',target:'view2',url:'#view2'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view2',target:'view2',url:'#view2'}">
 					View 2 top
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view3',target:'view3',url:'#view3'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view3',target:'view3',url:'#view3'}">
 					View 3 left
 				</li>
-				<li data-dojo-type="dojox.mobile.ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'view4',target:'view4',url:'#view4'}">
 					View 4 left
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'-view7',target:'-view7',url:'#-view7'}">

--- a/tests/borderLayoutApp/views/repeat.js
+++ b/tests/borderLayoutApp/views/repeat.js
@@ -51,7 +51,6 @@ function(dom, connect, registry, at, TransitionEvent, Repeat, getStateful, Outpu
 	};
 
 	return {
-		// repeate view init
 		init: function(){
 			repeatmodel = this.loadedModels.repeatmodels;
 			var repeatDom = dom.byId('repeatWidget');
@@ -74,7 +73,6 @@ function(dom, connect, registry, at, TransitionEvent, Repeat, getStateful, Outpu
 			});
 			_connectResults.push(connectResult);
 		},
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/borderLayoutApp/views/repeatDetails.js
+++ b/tests/borderLayoutApp/views/repeatDetails.js
@@ -23,7 +23,7 @@ function(dom, connect, registry, at, getStateful, Output){
 	};
 
 	return {
-		// repeate view init
+		// repeatDetails view init
 		init: function(){
 			repeatmodel = this.loadedModels.repeatmodels;
 		},

--- a/tests/layoutApp/views/repeat.js
+++ b/tests/layoutApp/views/repeat.js
@@ -51,7 +51,6 @@ function(dom, connect, registry, at, TransitionEvent, Repeat, getStateful, Outpu
 	};
 
 	return {
-		// repeate view init
 		init: function(){
 			repeatmodel = this.loadedModels.repeatmodels;
 			var repeatDom = dom.byId('repeatWidget');
@@ -74,7 +73,6 @@ function(dom, connect, registry, at, TransitionEvent, Repeat, getStateful, Outpu
 			});
 			_connectResults.push(connectResult);
 		},
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/layoutApp/views/repeatDetails.js
+++ b/tests/layoutApp/views/repeatDetails.js
@@ -23,7 +23,7 @@ function(dom, connect, registry, at, getStateful, Output){
 	};
 
 	return {
-		// repeate view init
+		// repeatDetails view init
 		init: function(){
 			repeatmodel = this.loadedModels.repeatmodels;
 		},

--- a/tests/layoutApp2/views/repeat.js
+++ b/tests/layoutApp2/views/repeat.js
@@ -51,7 +51,6 @@ function(dom, connect, registry, at, TransitionEvent, Repeat, getStateful, Outpu
 	};
 
 	return {
-		// repeate view init
 		init: function(){
 			repeatmodel = this.loadedModels.repeatmodels;
 			var repeatDom = dom.byId('repeatWidget');
@@ -74,7 +73,6 @@ function(dom, connect, registry, at, TransitionEvent, Repeat, getStateful, Outpu
 			});
 			_connectResults.push(connectResult);
 		},
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/layoutApp2/views/repeatDetails.js
+++ b/tests/layoutApp2/views/repeatDetails.js
@@ -23,7 +23,7 @@ function(dom, connect, registry, at, getStateful, Output){
 	};
 
 	return {
-		// repeate view init
+		// repeatDetails view init
 		init: function(){
 			repeatmodel = this.loadedModels.repeatmodels;
 		},

--- a/tests/longListTestApp/config.json
+++ b/tests/longListTestApp/config.json
@@ -1,0 +1,106 @@
+{
+	"id": "longListTestApp",
+	"name": "Scrollable Test App",
+	"description": "This is a test app for scrollable lists.",
+	"splash": "splash",
+
+	"loaderConfig": {
+		"paths": {
+			"longListTestApp": "../dojox/app/tests/longListTestApp"
+		}
+	},
+
+	"dependencies": [
+		"dojox/mobile/_base",
+		"dojox/mobile/_compat",
+		"dojox/mobile/Button",
+		"dojox/mobile/Heading",
+		"dojox/mobile/ListItem",
+		"dojox/mobile/RoundRectList",
+		"dojox/mobile/RoundRectCategory",
+		"dojox/mobile/EdgeToEdgeStoreList",
+		"dojox/mobile/LongListMixin",
+		"dojox/app/widgets/Container",
+		"dojo/store/Memory",
+		"dojo/store/Observable",
+		"dojox/mobile/ScrollableView"
+	],
+	// Modules for the application.  They are basically used as the second
+	// array of mixins in a dojo.declare().  Modify the top level behavior
+	// of the application, how it processes the config or any other life cycle
+	// by creating and including one or more of these
+	"modules": [
+		"longListTestApp/longListTestApp"
+	],
+
+	"controllers": [
+		"dojox/app/controllers/History",
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/controllers/Layout"
+	],
+
+	//stores we are using
+	"stores": {
+		"longlistStore":{
+	       "type": "dojo/store/Memory",
+	       "observable": true,
+		   "params": {
+                "data": "modelApp.list"
+		   }
+		}	   
+	},
+	
+	"has" : {
+		"phone" : {
+			"defaultView": "Header1,LongList1",
+			"isTablet" : false
+		},
+		"tablet" : {
+			"template": "longListTestApp/templates/tablet/ViewScrollableLists.html",
+			"definition": "longListTestApp/views/tablet/ViewScrollableLists",
+			"defaultView": "Header1,LongList1",
+			"isTablet" : true
+		}
+	},	
+
+	// these are the possible transitions, 
+	// if a transition is set on a view or parent it will override the transition set on the transitionEvent or the defaultTransition in the config.
+	"transition": "slide",
+
+	//views are groups of views and models loaded at once
+	"views": {
+		"configuration": {
+			"defaultView": "ScrollableListSelection",
+			"transition": "slide",
+			"definition": "none",
+
+			"views": {
+				"ScrollableListSelection": {
+					"template": "longListTestApp/templates/configuration/ScrollableListSelection.html"
+				}
+			}
+		},
+		"Header1": {
+			"template": "longListTestApp/templates/Header1.html",
+			"views": {
+				"TestInfo": {
+					"transition": "none",
+					"template": "longListTestApp/templates/TestInfo.html",
+					"definition": "longListTestApp/views/TestInfo.js"
+				},
+				"LongList1": {
+					"template": "longListTestApp/templates/LongList1.html",
+					"definition": "longListTestApp/views/LongList1.js"
+				},
+				"LongList3": {
+					"template": "longListTestApp/templates/LongList3.html",
+					"definition": "longListTestApp/views/LongList3.js"
+				}
+			}
+		},
+		"LongList2": {
+			"template": "longListTestApp/templates/LongList2.html"
+		}
+	}
+}

--- a/tests/longListTestApp/css/demo.css
+++ b/tests/longListTestApp/css/demo.css
@@ -1,0 +1,12 @@
+html,body {
+	width: 100%;
+	height: 100%;
+	background-color: black;
+}
+.lineItemPreventTouch {
+	width:2.5em;
+	height:3em; 
+	position:absolute; 
+	margin-left: -8px;
+	margin-top: -11px;
+}

--- a/tests/longListTestApp/css/tablet.css
+++ b/tests/longListTestApp/css/tablet.css
@@ -1,0 +1,81 @@
+#header button {
+	position:absolute;
+	margin:0px;
+}
+
+#navButton {
+	width:60px;
+}
+
+#loadDiv {
+	position:absolute;
+	left:0px;
+	top:0px;
+	width:100%;
+	height:100%;
+	z-index:999;
+}
+#loadDiv {
+	display:table;
+	font-size: 20px;
+	text-align:center;
+	background-color:white;
+}
+#loadDiv span {
+	display:table-cell;
+	vertical-align:middle;
+}
+
+body .mblProgContainer {
+	top:45%;
+	height: 45px;
+	width: 140px;
+	margin-left:-70px;
+	background-color: #2A2A28;
+	border-style: solid;
+	border-width: 2px;
+	border-color: #666666;
+	border-radius: 0.4em;
+	-webkit-border-radius: 0.4em;
+	-moz-border-radius: 0.4em;
+}
+
+body .mblProgContainer > div {
+	height: 100%;
+	width: 100%;
+	line-height: 45px;
+	vertical-align: middle;
+	font-size: 20px;
+	color: #c2c2c2;
+}
+
+body .mblProg {
+	left: 3px;
+	top: 3px;
+}
+
+body .mblProgContainer > div::after {
+	padding-left: 42px;
+	content: "Updating...";
+}
+
+#jsContent, #htmlContent {
+	padding-left:2px;
+}
+
+@media screen and (max-width: 600px) {
+	#jsContent, #htmlContent {
+		font-size: 14px;
+	}
+}
+
+.hidden {
+	display:none;
+}
+
+div .navPane {
+	width:250px;
+	border-right:1px solid black;
+	background-color: #C5CCD3;
+	z-index:100;
+}

--- a/tests/longListTestApp/index.html
+++ b/tests/longListTestApp/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+		<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"/>
+		<meta name="apple-mobile-web-app-capable" content="yes"/>		
+		<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+		<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">		
+		<title>Scrollable Test App</title>
+		<link rel="stylesheet" type="text/css" href="css/tablet.css">
+		<link type="text/css" href="css/demo.css" rel="stylesheet">
+	<style>
+	.subject {
+		font: bold 16px Helvetica;
+	}
+	.textBox {
+		font-size: 12px; 
+		font-weight: normal;
+		overflow: hidden;
+	}
+	</style>
+	
+		
+		<script type="text/javascript" src="../../../../dojox/mobile/deviceTheme.js"
+   					data-dojo-config="mblThemeFiles:['@theme',['dojox/app/tests/longListTestApp','todo']]"></script>
+
+		<script type="text/javascript" src="../../../../dojo/dojo.js" data-dojo-config="parseOnLoad: false,
+				mblHideAddressBar: true,
+				mblAndroidWorkaround: false,
+				mblAlwaysHideAddressBar: true,
+				app: {debugApp: 1},  // set debugApp to log app transtions and view activate/deactivate
+				mvc: {debugBindings: 0},  // set on to debug mvc data bindings
+				async: 1">
+		</script>
+		<script>
+			require(["./src.js"], function(){
+			});
+		</script>
+		
+	</head>
+	<body style="overflow-y:hidden; overflow-x:hidden;">
+	</body>
+</html>

--- a/tests/longListTestApp/longListTestApp.js
+++ b/tests/longListTestApp/longListTestApp.js
@@ -1,0 +1,30 @@
+define(["dojox/mobile/ProgressIndicator","dijit/registry"], function(ProgressIndicator, registry){
+	return function(){
+		// the default select_item is 0, or will throw an error if directly transition to #details,EditTodoItem view
+		this.selected_item = 0;
+		this.selected_configuration_item = 0;
+		this.progressIndicator = null;
+		/*
+	 	* show or hide global progress indicator
+	 	*/
+	 	
+		this.showProgressIndicator = function(show){
+				
+			if(!this.progressIndicator){
+				this.progressIndicator = ProgressIndicator.getInstance({removeOnStop:false, startSpinning:true, size:40, center:true, interval:30});
+				// TODO: use dojo.body will throw no appendChild method error.
+				var body = document.getElementsByTagName("body")[0];
+				body.appendChild(this.progressIndicator.domNode);
+				this.progressIndicator.domNode.style.zIndex = 999;
+			}
+			if(show){
+				this.progressIndicator.domNode.style.visibility = "visible";
+				this.progressIndicator.start();
+			}else{
+				this.progressIndicator.stop();
+				this.progressIndicator.domNode.style.visibility = "hidden";
+			}
+			
+		}
+	};
+});

--- a/tests/longListTestApp/resources/data/repeat.json
+++ b/tests/longListTestApp/resources/data/repeat.json
@@ -1,0 +1,105 @@
+{
+  "identifier": "Serial",
+   "items": [ 
+                    {
+                        "Serial"  : "A111",
+                        "First"   : "Anne",
+                        "Last"    : "Ackerman",
+                        "Location": "NY",
+                        "Office"  : "1S76",
+                        "Email"   : "a.a@test.com",
+                        "Tel"     : "123-764-8237",
+                        "Fax"     : "123-764-8228"
+                    },
+                    {
+                        "Serial"  : "B111",
+                        "First"   : "Ben",
+                        "Last"    : "Beckham",
+                        "Location": "NY",
+                        "Office"  : "5N47",
+                        "Email"   : "b.b@test.com",
+                        "Tel"     : "123-764-8599",
+                        "Fax"     : "123-764-8600"
+                    },
+                    {
+                        "Serial"  : "C111",
+                        "First"   : "Chad",
+                        "Last"    : "Chapman",
+                        "Location": "CA",
+                        "Office"  : "1278",
+                        "Email"   : "c.c@test.com",
+                        "Tel"     : "408-764-8237",
+                        "Fax"     : "408-764-8228"
+                    },
+                    {
+                        "Serial"  : "D111",
+                        "First"   : "David",
+                        "Last"    : "Durham",
+                        "Location": "NJ",
+                        "Office"  : "C12",
+                        "Email"   : "d.d@test.com",
+                        "Tel"     : "514-764-8237",
+                        "Fax"     : "514-764-8228"
+                    },
+                    {
+                        "Serial"  : "E111",
+                        "First"   : "Emma",
+                        "Last"    : "Eklof",
+                        "Location": "NY",
+                        "Office"  : "4N76",
+                        "Email"   : "e.e@test.com",
+                        "Tel"     : "123-764-1234",
+                        "Fax"     : "123-764-4321"
+                    },
+                    {
+                        "Serial"  : "F111",
+                        "First"   : "Fred",
+                        "Last"    : "Fisher",
+                        "Location": "NJ",
+                        "Office"  : "V89",
+                        "Email"   : "f.f@test.com",
+                        "Tel"     : "514-764-8567",
+                        "Fax"     : "514-764-8000"
+                    },
+                    {
+                        "Serial"  : "G111",
+                        "First"   : "George",
+                        "Last"    : "Garnett",
+                        "Location": "NY",
+                        "Office"  : "7S11",
+                        "Email"   : "gig@test.com",
+                        "Tel"     : "123-999-8599",
+                        "Fax"     : "123-999-8600"
+                    },
+                    {
+                        "Serial"  : "H111",
+                        "First"   : "Hunter",
+                        "Last"    : "Huffman",
+                        "Location": "CA",
+                        "Office"  : "6532",
+                        "Email"   : "h.h@test.com",
+                        "Tel"     : "408-874-8237",
+                        "Fax"     : "408-874-8228"
+                    },
+                    {
+                        "Serial"  : "I111",
+                        "First"   : "Irene",
+                        "Last"    : "Ira",
+                        "Location": "NJ",
+                        "Office"  : "F09",
+                        "Email"   : "i.i@test.com",
+                        "Tel"     : "514-764-6532",
+                        "Fax"     : "514-764-7300"
+                    },
+                    {
+                        "Serial"  : "J111",
+                        "First"   : "John",
+                        "Last"    : "Jacklin",
+                        "Location": "CA",
+                        "Office"  : "6701",
+                        "Email"   : "j.j@test.com",
+                        "Tel"     : "408-764-1234",
+                        "Fax"     : "408-764-4321"
+                    }
+                ]
+}

--- a/tests/longListTestApp/src.js
+++ b/tests/longListTestApp/src.js
@@ -1,0 +1,24 @@
+require(["dojo/_base/window","dojox/app/main", "dojox/json/ref", "dojo/sniff"],
+	function(win, Application, json, has){
+	win.global.modelApp = {};
+	modelApp.list = { 
+		identifier: "label",
+		'items':[]
+	};
+
+	var isTablet = false;
+
+	var configurationFile = "./config.json";
+	if(window.innerWidth > 600){
+		isTablet = true;
+	}
+
+	require(["dojo/text!"+configurationFile], function(configJson){
+		var config = json.fromJson(configJson);
+		has.add("tablet", isTablet);
+		has.add("phone", !isTablet);
+		has.add("ie9orLess", has("ie") && !has("ie") >= 10);
+		has.add("notie9orLess", !has("ie") || has("ie") >= 10);
+		Application(config);
+	});
+});

--- a/tests/longListTestApp/templates/Header1.html
+++ b/tests/longListTestApp/templates/Header1.html
@@ -1,0 +1,8 @@
+<div class="view mblView">
+	<h1 id="heading1" data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List One"' data-app-constraint="top">
+		<span id="sc1back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
+		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration,ScrollableListSelection', url: '#configuration,ScrollableListSelection', transitionDir: -1}">Back</span>
+		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc1insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">5</span>
+
+	</h1>     
+</div>

--- a/tests/longListTestApp/templates/LongList1.html
+++ b/tests/longListTestApp/templates/LongList1.html
@@ -1,0 +1,14 @@
+<div class="view mblView">
+	<div data-app-constraint="top">
+	</div>
+
+	<div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" data-dojo-props="scrollable: true">
+
+		<div class="field-title">Should scroll from under the top header to the end of the page, this text will also scroll.</div>
+
+		<form name="repeatTestForm">
+				<ul data-dojo-type="dojox/mobile/EdgeToEdgeStoreList" data-dojo-mixins="dojox/mobile/LongListMixin" id="list" data-dojo-props='append:true'></ul>
+	<!--			<ul data-dojo-type="dojox/mobile/EdgeToEdgeStoreList" id="list" data-dojo-props='append:true'></ul> -->
+		</form>
+	</div>
+</div>

--- a/tests/longListTestApp/templates/LongList2.html
+++ b/tests/longListTestApp/templates/LongList2.html
@@ -1,0 +1,21 @@
+<div class="view mblView">
+	<h1 id="heading2" data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Long List Two"' data-app-constraint="top">
+		<span id="sc2back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
+		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration,ScrollableListSelection', url: '#configuration,ScrollableListSelection', transitionDir: -1}">Back</span>
+		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc2insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">5</span>
+	</h1>     
+	<div data-app-constraint="top">
+		<div class="field-title">Should scroll between this text and the bottom footer.</div>
+	</div>     
+
+	<div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" data-dojo-props="scrollable: true">
+
+		<div class="field-title">Should scroll from under the top header to the end of the page, this text will also scroll.</div>
+
+		<form name="repeatTestForm3">
+				<ul data-dojo-type="dojox/mobile/EdgeToEdgeStoreList" data-dojo-mixins="dojox/mobile/LongListMixin" id="list2" data-dojo-props='append:true'></ul> 
+		<!--		<ul data-dojo-type="dojox/mobile/EdgeToEdgeStoreList" id="list3" data-dojo-props='append:true'></ul> -->
+				
+		</form>
+	</div>
+</div>

--- a/tests/longListTestApp/templates/LongList3.html
+++ b/tests/longListTestApp/templates/LongList3.html
@@ -1,0 +1,15 @@
+<div class="view mblView">
+	<div data-app-constraint="top">
+	</div>
+
+	<div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" data-dojo-props="scrollable: true">
+
+		<div class="field-title">Should scroll from under the top header to the end of the page, this text will also scroll.</div>
+
+		<form name="repeatTestForm3">
+				<ul data-dojo-type="dojox/mobile/EdgeToEdgeStoreList" data-dojo-mixins="dojox/mobile/LongListMixin" id="list3" data-dojo-props='append:true'></ul> 
+		<!--		<ul data-dojo-type="dojox/mobile/EdgeToEdgeStoreList" id="list3" data-dojo-props='append:true'></ul> -->
+				
+		</form>
+	</div>
+</div>

--- a/tests/longListTestApp/templates/TestInfo.html
+++ b/tests/longListTestApp/templates/TestInfo.html
@@ -1,0 +1,13 @@
+<div class="view mblView">
+
+	<div data-dojo-type="dojox/mobile/ScrollableView">
+		<div id="tst1WrapperB" style="visibility:hidden">
+			<div class="field-title">Each test is sharing an observable store and using an EdgeToEdgeStoreList with a LongListMixin.</div>
+			<div class="field-title">Use the +5 button to add 5 rows to the lists, it will update all lists.</div>
+			<br>
+			<div class="field-title">There was a problem with LongListMixin in a scrollable view where it would not get added on the pages which were not visible when the rows were added, but now it is fixed.</div>
+			<br><br>
+			<br>
+		</div>
+	</div>
+</div>

--- a/tests/longListTestApp/templates/configuration/ScrollableListSelection.html
+++ b/tests/longListTestApp/templates/configuration/ScrollableListSelection.html
@@ -1,0 +1,45 @@
+<div class="view mblView">
+	
+	<div>
+	<div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" data-dojo-props="scrollable: true">
+		
+			<ul data-dojo-type="dojox/mobile/RoundRectList"  data-dojo-props='variableHeight:true'>
+				<li data-dojo-type="dojox/mobile/ListItem"
+					data-dojo-props="clickable: true, noArrow: true, 
+					transitionOptions: {title:'List',target: 'Header1,LongList1', url: '#Header1,LongList1'}">
+					<div class="textBox">
+						<div class="subject">Long List One</div>
+						Uses app/widgets/Container with a parent Header view no footer with data-app-constraint and EdgeToEdgeStoreList				
+					</div>				
+				</li>
+			
+				<li data-dojo-type="dojox/mobile/ListItem"
+					data-dojo-props="clickable: true, noArrow: true, 
+					transitionOptions: {title:'List',target: 'LongList2', url: '#LongList2'}">
+					<div class="textBox">
+						<div class="subject">Long List Two</div>
+						Uses app/widgets/Container with a fixed Header no footer with data-app-constraint and EdgeToEdgeStoreList				
+					</div>				
+				</li>
+			
+				<li data-dojo-type="dojox/mobile/ListItem"
+					data-dojo-props="clickable: true, noArrow: true, 
+					transitionOptions: {title:'List',target: 'Header1,LongList3', url: '#Header1,LongList3'}">
+					<div class="textBox">
+						<div class="subject">Long List Three</div>
+						Uses app/widgets/Container with a fixed Header no footer with data-app-constraint and EdgeToEdgeStoreList				
+					</div>				
+				</li>
+				
+				<li data-dojo-type="dojox/mobile/ListItem"
+					data-dojo-props="clickable: true, noArrow: true, 
+					transitionOptions: {title:'List',target: 'Header1,TestInfo', url: '#Header1,TestInfo'}">
+					<div class="textBox">
+						<div class="subject">Test Instructions</div>
+						Test instructions, notes and known problems (transition none)				
+					</div>				
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>

--- a/tests/longListTestApp/templates/tablet/ViewScrollableLists.html
+++ b/tests/longListTestApp/templates/tablet/ViewScrollableLists.html
@@ -1,0 +1,47 @@
+<div>
+	<!-- left -->
+	<div data-dojo-type="dojox/app/widgets/Container" class="navPane" data-app-constraint="left">
+		<h1 id="tab1WrapperA" style="visibility:hidden" data-dojo-type="dojox/mobile/Heading" data-app-constraint="top">Select Scrollable List</h1>
+		<div  id="tab1WrapperB" style="visibility:hidden" 
+			data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" data-dojo-props="scrollable: true">
+		<ul data-dojo-type="dojox/mobile/RoundRectList" data-dojo-props='variableHeight:true'>
+			
+				<li data-dojo-type="dojox/mobile/ListItem"
+					data-dojo-props="clickable: true, noArrow: true, 
+					transitionOptions: {title:'List',target: 'Header1,LongList1', url: '#Header1,LongList1'}">
+					<div class="textBox">
+						<div class="subject">Long List One</div>
+						Uses app/widgets/Container with a parent Header view no footer with data-app-constraint and EdgeToEdgeStoreList				
+					</div>				
+				</li>
+
+				<li data-dojo-type="dojox/mobile/ListItem"
+					data-dojo-props="clickable: true, noArrow: true, 
+					transitionOptions: {title:'List',target: 'LongList2', url: '#LongList2'}">
+					<div class="textBox">
+						<div class="subject">Long List Two</div>
+						Uses app/widgets/Container with a fixed Header no footer with data-app-constraint and EdgeToEdgeStoreList				
+					</div>				
+				</li>
+			
+				<li data-dojo-type="dojox/mobile/ListItem"
+					data-dojo-props="clickable: true, noArrow: true, 
+					transitionOptions: {title:'List',target: 'Header1,LongList3', url: '#Header1,LongList3'}">
+					<div class="textBox">
+						<div class="subject">Long List Three</div>
+						Uses app/widgets/Container with a fixed Header no footer with data-app-constraint and EdgeToEdgeStoreList				
+					</div>				
+				</li>
+				
+				<li data-dojo-type="dojox/mobile/ListItem"
+					data-dojo-props="clickable: true, noArrow: true, 
+					transitionOptions: {title:'List',target: 'Header1,TestInfo', url: '#Header1,TestInfo'}">
+					<div class="textBox">
+						<div class="subject">Test Instructions</div>
+						Test instructions, notes and known problems (transition none)				
+					</div>				
+				</li>
+		</ul>
+	</div>
+</div>
+

--- a/tests/longListTestApp/themes/android/todo.css
+++ b/tests/longListTestApp/themes/android/todo.css
@@ -1,0 +1,25 @@
+/* dojox.mobile.TextArea */
+.mblTextArea {
+  padding-left: 5px;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 1px;
+
+  font-size: 21px;
+  color: white;
+
+  border: 1px solid #ADAAAD;
+  border-radius: 8px;
+  background-color: black;
+}
+div .navPane {
+	background-color: black !important;
+	border-right: 1px solid #ADAAAD !important;
+}
+button.baseBtn {
+  font-family: Helvetica;
+  font-size: 17px;
+  font-weight: bold;
+  height: 48px;
+  margin-bottom: 6px;
+}

--- a/tests/longListTestApp/themes/blackberry/todo.css
+++ b/tests/longListTestApp/themes/blackberry/todo.css
@@ -1,0 +1,21 @@
+/* dojox.mobile.TextArea */
+.mblTextArea {
+  font-size: 18px;
+
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-left: 7px;
+  
+  border: 1px solid #c6c7c6;
+  border-radius: 6px;
+  background-color: white;
+}
+/* dojox.mobile.ExpandingTextArea */
+.mblExpandingTextArea {
+  margin: 0px;
+}
+button.baseBtn {
+  font-size: 18px;
+  height: 48px;
+  margin-bottom: 8px;
+}

--- a/tests/longListTestApp/themes/iphone/todo.css
+++ b/tests/longListTestApp/themes/iphone/todo.css
@@ -1,0 +1,31 @@
+/* dojox.mobile.TextArea */
+.mblTextArea {
+  font-family: Helvetica;
+  font-size: 17px;
+  font-weight: bold;
+  color: #324f85;
+  
+  padding-left: 8px;
+  padding-right: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+
+  border-bottom-width: 0;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  border-bottom-style: solid;
+  border-bottom-color: #ADAAAD;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+/* dojox.mobile.ExpandingTextArea */
+.mblExpandingTextArea {
+  margin: 0px;
+}
+button.baseBtn {
+  font-family: Helvetica;
+  font-size: 17px;
+  font-weight: bold;
+  height: 40px;
+  margin-bottom: 8px;
+}

--- a/tests/longListTestApp/views/Header1.js
+++ b/tests/longListTestApp/views/Header1.js
@@ -1,0 +1,68 @@
+define(["dojo/dom", "dojo/dom-style", "dojo/_base/connect", "dojo/store/Memory", "dojo/store/Observable"],
+function(dom, domStyle, connect, Memory, Observable){
+
+		var _connectResults = []; // events connect result
+		var backId = 'sc1back1';
+		var insert10Id = 'sc1insert10x';
+		var	loadMoreItem = null;
+		var app = null;
+		
+		loadMore=function(){
+			if(!app){
+				return;
+			}
+			if(!app.listStart){
+				app.listStart = 1;
+				app.listCount = 5;
+			}
+			setTimeout(function(){ // to simulate network latency
+				for(i = app.listStart; i < app.listStart+5; i++){
+					var newdata = {'label': 'Item #'+i};
+					app.stores.longlistStore.store.put(newdata);
+				}
+				app.listStart += app.listCount;
+				app.listTotal = app.listStart-1;				
+				return false;
+			}, 500);
+		};
+	return {
+		init: function(){
+			app = this.app;
+			var memoryStore = new Memory({data: {}});
+			store = new Observable(memoryStore);
+
+			var connectResult;
+			connectResult = connect.connect(dom.byId(insert10Id), "click", function(){
+				//Add 10 items to the end of the model
+				loadMore();
+			});
+			_connectResults.push(connectResult);
+		},
+
+
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			if(dom.byId(backId) && this.app.isTablet){ 
+				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
+			}
+			if(dom.byId("tab1WrapperA")){ 
+				domStyle.set(dom.byId("tab1WrapperA"), "visibility", "visible");  // show the nav view if it being used
+				domStyle.set(dom.byId("tab1WrapperB"), "visibility", "visible");  // show the nav view if it being used
+			}
+		},
+
+		afterActivate: function(){
+			// summary:
+			//		view life cycle afterActivate()
+		},
+				
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/longListTestApp/views/LongList1.js
+++ b/tests/longListTestApp/views/LongList1.js
@@ -1,0 +1,40 @@
+define(["dojo/dom", "dojo/dom-style", "dojo/_base/connect","dijit/registry"],
+function(dom, domStyle, connect, registry){
+		var _connectResults = []; // events connect result
+		var	list = null;
+		var listId = 'list';
+		var app = null;
+	return {
+		init: function(){
+			app = this.app;
+		},
+
+
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			app.list1 = registry.byId(listId);
+
+			list = app.list1;
+			if(!list.Store){
+				list.setStore(app.stores.longlistStore.store);
+			}
+
+			if(registry.byId("heading1")){
+				registry.byId("heading1").labelDivNode.innerHTML = "Long List One";
+			}
+			if(dom.byId("tab1WrapperA")){ 
+				domStyle.set(dom.byId("tab1WrapperA"), "visibility", "visible");  // show the nav view if it being used
+				domStyle.set(dom.byId("tab1WrapperB"), "visibility", "visible");  // show the nav view if it being used
+			}
+		},
+		
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/longListTestApp/views/LongList2.js
+++ b/tests/longListTestApp/views/LongList2.js
@@ -1,0 +1,49 @@
+define(["dojo/dom", "dojo/dom-style", "dojo/_base/connect","dijit/registry"],
+function(dom, domStyle, connect, registry){
+		var _connectResults = []; // events connect result
+		var	list = null;
+		var listId = 'list2';
+		var backId = 'sc2back1';
+		var insert10Id = 'sc2insert10x';
+		var app = null;
+	return {
+		init: function(){
+			app = this.app;
+			
+			var connectResult;
+			connectResult = connect.connect(dom.byId(insert10Id), "click", function(){
+				//Add 5 items to the end of the model
+				loadMore();
+			});
+		},
+
+
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			if(dom.byId(backId) && this.app.isTablet){ 
+				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
+			}
+			
+			app.list2 = registry.byId(listId);
+
+			list = app.list2;
+			if(!list.store){
+				list.setStore(app.stores.longlistStore.store);
+			}
+
+			if(dom.byId("tab1WrapperA")){ 
+				domStyle.set(dom.byId("tab1WrapperA"), "visibility", "visible");  // show the nav view if it being used
+				domStyle.set(dom.byId("tab1WrapperB"), "visibility", "visible");  // show the nav view if it being used
+			}
+		},
+		
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/longListTestApp/views/LongList3.js
+++ b/tests/longListTestApp/views/LongList3.js
@@ -1,0 +1,42 @@
+define(["dojo/dom", "dojo/dom-style", "dojo/_base/connect","dijit/registry"],
+function(dom, domStyle, connect, registry){
+
+		var _connectResults = []; // events connect result
+		var	list = null;
+		var listId = 'list3';
+		var app = null;
+	return {
+		init: function(){
+			app = this.app;
+		},
+
+
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			// description:
+			//		beforeActivate will save the list is app and set the store on the list
+			app.list3 = registry.byId(listId);
+			list = app.list3;
+			if(!list.store){
+				list.setStore(app.stores.longlistStore.store);
+			}
+
+			if(registry.byId("heading1")){
+				registry.byId("heading1").labelDivNode.innerHTML = "Long List Three";
+			}
+			if(dom.byId("tab1WrapperA")){ 
+				domStyle.set(dom.byId("tab1WrapperA"), "visibility", "visible");  // show the nav view if it being used
+				domStyle.set(dom.byId("tab1WrapperB"), "visibility", "visible");  // show the nav view if it being used
+			}
+		},
+
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/longListTestApp/views/TestInfo.js
+++ b/tests/longListTestApp/views/TestInfo.js
@@ -1,0 +1,37 @@
+define(["dojo/dom", "dojo/dom-style", "dojo/_base/connect"],
+function(dom, domStyle, connect){
+		var _connectResults = []; // events connect result
+		var backId = 'ti1back1';
+		var wrapperIdB = 'tst1WrapperB';
+	return {
+		init: function(){			
+		},
+
+
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			if(dom.byId(backId) && this.app.isTablet){ 
+				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
+			}
+			if(dom.byId("tab1WrapperB") && this.app.isTablet){ 
+				domStyle.set(dom.byId("tab1WrapperB"), "visibility", "visible");  // show the nav view if it being used
+			}
+			domStyle.set(dom.byId(wrapperIdB), "visibility", "visible");  // show the view when it is ready
+		},
+
+		afterActivate: function(){
+			// summary:
+			//		view life cycle afterActivate()
+		},
+		
+		
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/longListTestApp/views/configuration/ScrollableListSelection.js
+++ b/tests/longListTestApp/views/configuration/ScrollableListSelection.js
@@ -1,0 +1,28 @@
+define(["dojo/dom", "dojo/_base/lang", "dojo/dom-style", "dijit/registry"],
+	function(dom, lang, domStyle, registry){
+
+		var wrapperId = 'cfg1Wrapper';
+		var app = null;
+
+	return {
+		init: function(){
+			app = this.app;
+		},
+		
+		beforeActivate: function(){
+			app.stopTransition = false;
+		},
+		
+		afterActivate: function(){
+		},
+		
+		beforeDeactivate: function(){
+		},
+
+		afterDeactivate: function(){
+		},
+
+		destroy: function(){
+		}
+	}
+});

--- a/tests/longListTestApp/views/tablet/ViewScrollableLists.js
+++ b/tests/longListTestApp/views/tablet/ViewScrollableLists.js
@@ -1,0 +1,34 @@
+define(["dojo/_base/lang", "dojo/dom", "dojo/dom-style", "dijit/registry", "dojox/mobile/TransitionEvent"],
+function(lang, dom, domStyle, registry, TransitionEvent){
+	selectItems = function(node, index){
+		//if(this.app.selected_configuration_item == index){
+		//	return;
+		//}
+		this.app.selected_configuration_item = index;
+
+	};
+	return {
+		init: function(){
+			console.log("navigation view init ok");
+		},
+
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle afterActivate()
+			console.log("ViewScrollableLists view beforeActivate called");
+		// this will be done in the other views, since beforeActivate is not called for the left view...
+		//	if(dom.byId("tab1WrapperA")){ 
+		//		domStyle.set(dom.byId("tab1WrapperA"), "visibility", "visible");  // show the nav view if it being used
+		//		domStyle.set(dom.byId("tab1WrapperB"), "visibility", "visible");  // show the nav view if it being used
+		//	}
+		},
+
+		afterActivate: function(){
+			// summary:
+			//		view life cycle afterActivate()
+			console.log("ViewScrollableLists view beforeActivate called");
+		}
+		
+		
+	};
+});

--- a/tests/mediaQueryLayoutApp/build.profile.js
+++ b/tests/mediaQueryLayoutApp/build.profile.js
@@ -1,0 +1,32 @@
+require(["dojox/app/build/buildControlApp"], function(bc){
+});
+
+var profile = {
+	basePath: "..",
+	releaseDir: "./layoutApp/release",
+	action: "release",
+	cssOptimize: "comments",
+/*	multipleAppConfigLayers: true,*/
+	packages:[{
+		name: "dojo",
+		location: "../../../dojo"
+	},{
+		name: "dijit",
+		location: "../../../dijit"
+	},{
+		name: "layoutApp",
+		location: "../../../dojox/app/tests/layoutApp",
+		destLocation: "./dojox/app/tests/layoutApp"
+	},{
+		name: "dojox",
+		location: "../../../dojox"
+	}],
+	layers: {
+		"layoutApp/layoutApp": {
+			include: [ "layoutApp/index.html" ]
+		}
+	}
+};
+
+
+

--- a/tests/mediaQueryLayoutApp/config.json
+++ b/tests/mediaQueryLayoutApp/config.json
@@ -1,0 +1,133 @@
+{
+	"id": "mediaQueryLayoutApp",
+	"name": "mediaQuery Layout App",
+	"description": "A mediaQuery Layout App",
+	"splash": "splash",
+
+	"loaderConfig": {
+		"paths": {
+			"mediaQueryLayoutApp": "../dojox/app/tests/mediaQueryLayoutApp"
+		}
+	},
+
+	"dependencies": [
+		"dojox/app/utils/mvcModel",
+		"dojox/mobile/_base",
+		"dojox/mobile/compat",
+		"dojox/mobile/TabBar",
+		"dojox/mobile/RoundRect",
+		"dojox/mobile/TabBarButton",
+		"dojox/mobile/Button",
+		"dojox/mobile/RoundRect",
+		"dojox/mobile/Heading",
+		"dojox/mobile/ScrollableView",
+		"dojo/store/Memory",
+		"dojox/mvc/EditStoreRefListController",
+		"dojox/mvc/Group",
+        "dojox/mvc/Repeat",
+        "dojox/mvc/Output",
+		"dojox/mobile/View",
+		"dojox/app/widgets/Container"
+	],
+
+	"modules": [],
+	
+	"controllers": [
+		"dojox/app/controllers/History",
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/tests/mediaQueryLayoutApp/controllers/CssLayout"
+	],
+
+	//stores we are using
+	"stores": {
+	   "namesStore":{
+	       "type": "dojo/store/Memory",
+		   "params": {
+		      "data": "modelApp.names"
+		   }
+	   },
+       "repeatStore":{
+           "type": "dojo/store/Memory",
+           "params": {
+                "data": "modelApp.repeatData"
+           }
+       }
+	},
+
+	//models and instantiation parameters for the models. Including 'type' as a property allows
+	//one to overide the class that will be used for the model.  By default it is dojox/mvc/model
+	"models": {
+	   "names": {
+			"modelLoader": "dojox/app/utils/mvcModel",
+			"type": "dojox/mvc/EditStoreRefListController",
+			"params":{
+				"store": {"$ref":"#stores.namesStore"}
+			}	       
+	   },
+		"repeatmodels": {
+			"modelLoader": "dojox/app/utils/mvcModel",
+			"type": "dojox/mvc/EditStoreRefListController",
+			"params":{
+				"store": {"$ref":"#stores.repeatStore"}
+			}           
+		}
+	}, 
+
+
+	//the name of the view to load when the app is initialized.
+	"defaultView": "header+navigation+TestInfo",
+
+	// these are the possilbe defaultTransitions
+	"defaultTransition": "slide",
+	//"defaultTransition": "none",
+	//"defaultTransition": "fade",
+	//"defaultTransition": "flip",     
+
+	"views": {
+		"navigation":{
+			"definition" : "none",
+			"constraint" : "left",
+			"template": "mediaQueryLayoutApp/templates/navigation.html"
+		},
+		"TestInfo": {
+			"definition" : "mediaQueryLayoutApp/views/TestInfo.js",
+			"constraint" : "center",
+			"template": "mediaQueryLayoutApp/templates/TestInfo.html"
+		},	
+		"centerNavigation":{
+			"definition" : "mediaQueryLayoutApp/views/centerNavigation.js",
+			"constraint" : "center",
+			"template": "mediaQueryLayoutApp/templates/centerNavigation.html"
+		},
+		"header":{
+			"definition" : "none",
+			"constraint" : "top",
+			"template": "mediaQueryLayoutApp/templates/header.html"
+		},
+		"simple":{
+			"definition" : "mediaQueryLayoutApp/views/simple.js",
+			"constraint" : "center",
+			"template": "mediaQueryLayoutApp/templates/simple.html",
+			"dependencies":["dojox/mobile/TextBox"]
+		},
+
+		"repeatList":{
+			"definition" : "mediaQueryLayoutApp/views/repeat.js",
+			"template": "mediaQueryLayoutApp/templates/repeat.html",
+			"dependencies":["dojox/mobile/TextBox"]
+		},
+		"repeatDetails":{
+			"definition" : "mediaQueryLayoutApp/views/repeatDetails.js",
+			"template": "mediaQueryLayoutApp/templates/repeatDetails.html",
+			"dependencies":["dojox/mobile/TextBox"]
+		},
+
+		"generate": {
+			"definition": "mediaQueryLayoutApp/views/generate",
+            "template": "mediaQueryLayoutApp/templates/generate.html",
+			"constraint" : "center",            
+            "dependencies":["dojox/mobile/TextBox", "dojox/mobile/TextArea", "dojox/mvc/Generate"]
+		}
+	}	
+}

--- a/tests/mediaQueryLayoutApp/controllers/CssLayout.js
+++ b/tests/mediaQueryLayoutApp/controllers/CssLayout.js
@@ -1,0 +1,79 @@
+define(["dojo/_base/declare", "dojo/dom", "dojo/dom-style",
+		"dojo/dom-class", "dojo/dom-attr", "dojo/dom-construct", 
+		"dojox/app/controllers/LayoutBase", "dijit/registry"],
+function(declare, dom, domStyle, domClass, domAttr, domConstruct, LayoutBase, registry){
+	// module:
+	//		dojox/app/tests/mediaQueryLayoutApp/controllers/CssLayout
+	// summary:
+	//		Will layout an application with a BorderContainer.  
+	//		Each view to be shown in a region of the BorderContainer will be wrapped in a StackContainer and a ContentPane.
+	//		
+
+	return declare("dojox/app/tests/mediaQueryLayoutApp/controllers/CssLayout", LayoutBase, {
+
+		initLayout: function(event){
+			// summary:
+			//		Response to dojox/app "initLayout" event which is setup in LayoutBase.
+			//		The initLayout event is called once when the View is being created the first time.
+			//
+			// example:
+			//		Use emit to trigger "initLayout" event, and this function will respond to the event. For example:
+			//		|	this.app.emit("initLayout", view);
+			//
+			// event: Object
+			// |		{"view": view, "callback": function(){}};
+			this.app.log("in app/controllers/CssLayout.initLayout event.view.name=[",event.view.name,"] event.view.parent.name=[",event.view.parent.name,"]");
+
+
+			this.app.log("in app/controllers/CssLayout.initLayout event.view.constraint=",event.view.constraint);
+			var constraint = event.view.constraint;  // constraint holds the region for this view, center, top etc.
+			
+		//	if(event.view.parent.id == this.app.id){  // If the parent of this view is the app we are working with the BorderContainer
+			//	var reg = dom.byId(event.view.parent.id+"-"+constraint);			
+			//	if(reg){  // already has a wrapperNode, just add to it.
+			//		reg.appendChild(event.view.domNode);
+			//	}else{ // need a wrapperNode
+			//		var container;
+			//		event.view.parent.domNode.appendChild(container = domConstruct.create("div"));
+			//		container.appendChild(event.view.domNode);
+			//		domAttr.set(container, "id", event.view.parent.id+"-"+constraint);
+			//		domClass.add(event.view.domNode, constraint);  // set the class to the constraint
+			//	}
+		//	}else{ // Not a top level page transition, so not changing a page in the BorderContainer, so handle it like Layout.
+				event.view.parent.domNode.appendChild(event.view.domNode);
+				domClass.add(event.view.domNode, constraint);  // set the class to the constraint
+		//	}
+
+			this.inherited(arguments);
+		},
+
+		onResize: function(){
+			// do nothing on resize
+		},
+
+		hideView: function(view){
+			domStyle.set(view.domNode, "display", "none");
+			//var sc = registry.byId(view.parent.id+"-"+view.constraint);
+			//if(sc){
+			//	sc.removedFromBc = true;
+			//	sc.removeChild(view.domNode);
+			//}
+		},
+
+		showView: function(view){
+			domStyle.set(view.domNode, "display", "");
+			
+			//var sc = registry.byId(view.parent.id+"-"+view.constraint);
+			//if(sc){
+			//	if(sc.removedFromBc){
+			//		sc.removedFromBc = false;
+			//		registry.byId(this.app.id+"-BC").addChild(sc);
+			//		domStyle.set(view.domNode, "display", "");
+			//	}
+			//	domStyle.set(cp.domNode, "display", "");
+			//	sc.selectChild(cp);
+			//	sc.resize();
+			//}
+		}
+	});
+});

--- a/tests/mediaQueryLayoutApp/css/layoutApp.css
+++ b/tests/mediaQueryLayoutApp/css/layoutApp.css
@@ -1,0 +1,257 @@
+.center {
+	float: left;
+	width: 900px;
+	height: 100% 
+}
+
+.top {
+	float: top;
+}
+
+.left {
+	float: left; 
+	width:250px;
+	border-right:1px solid black;
+	background-color: #C5CCD3;
+	z-index:100;	
+	height: 100% 
+}
+
+#headerBackButton {
+	display: none;
+}
+
+@media screen and (max-width: 1154px) {
+	.center {
+		float: left;
+		width: 600px 
+	}
+
+	.left {
+		float: left; 
+		width:250px;
+		border-right:1px solid black;
+		background-color: #C5CCD3;
+		z-index:100;	
+		height: 100% 
+	}
+
+}
+
+@media screen and (max-width: 854px) {
+	.center {
+		float: left;
+		width: 520px;
+		height: 100%;
+		
+	}
+
+	.left {
+		float: left; 
+		width:250px;
+		border-right:1px solid black;
+		background-color: #C5CCD3;
+		z-index:100;	
+		height: 100% 
+	}
+
+}
+
+@media screen and (max-width: 560px) {
+	.center {
+		float: left;
+		width: 100%; 
+	}
+
+	.left {
+		display: none;
+		float: left; 
+		width:0px;
+	}
+
+	#headerBackButton {
+		display: block;
+	}
+
+}
+
+
+@media only screen and (orientation: portrait) {
+	.center {
+		float: left;
+		width: 100%; 
+	}
+
+	.left {
+		display: none;
+		float: left; 
+		width:0px;
+	}
+
+	#headerBackButton {
+		display: block;
+	}
+}
+
+@media only screen and (orientation: landscape) and (max-width: 568px) {
+	.center {
+		float: left;
+		width: 360px;
+		height: 100%;
+		
+	}
+
+	.left {
+		float: left; 
+		width:150px;
+		border-right:1px solid black;
+		background-color: #C5CCD3;
+		z-index:100;	
+		height: 100% 
+	}
+
+}
+
+/*@media only screen and (device-width: 480px) and (orientation: landscape) and (resolution: 163dpi) { */
+	/* CSS3 Rules for XX iPhone in Portrait Orientation */
+/*@media only screen and (device-width: 568px) and (orientation: landscape) {
+	.center {
+		float: left;
+		width: 300px;
+		height: 100%;
+		
+	}
+
+	.left {
+		float: left; 
+		width:100px;
+		border-right:1px solid black;
+		background-color: #C5CCD3;
+		z-index:100;	
+		height: 100% 
+	}
+}
+*/
+
+
+
+html,body {
+	width: 100%;
+	height: 100%;
+}
+
+button.baseBtn {
+	-webkit-background-clip: padding-box;
+	-webkit-box-align: center;
+	background-clip: padding-box;
+	border-style: solid;
+	border-width: 1px;
+	color: black;
+	font-family: 'Helvetica Neue', HelveticaNeue, Helvetica-Neue, Helvetica, 'BBAlpha Sans';
+	font-size: 18px;
+	font-weight: bold;
+	vertical-align: middle;
+	margin: 10px;
+	height: 34px;
+	border-bottom-left-radius: 7px;
+	border-bottom-right-radius: 7px;
+	border-top-left-radius: 7px;
+	border-top-right-radius: 7px;
+	width: 240px;
+}
+
+button.whiteBtn{
+	background-image: -webkit-gradient(linear, 0% 0, 0% 100%, from(white), color-stop(0.06, #f2f2f2), to(#b7b7b7));
+	border-color: #979797;
+	border-bottom-color: #727272;
+}
+
+button.whiteBtnSelected{
+	background-image: -webkit-gradient(linear, 0% 0, 0% 100%, from(#ffffff), color-stop(0.06, #bbbbbb), to(#fcfcfc));
+	border-color: #979797;
+	border-bottom-color: #727272;
+}
+
+#header button {
+	position:absolute;
+	margin:0px;
+}
+
+#navButton {
+	width:60px;
+}
+
+#loadDiv {
+	position:absolute;
+	left:0px;
+	top:0px;
+	width:100%;
+	height:100%;
+	z-index:999;
+}
+#loadDiv {
+	display:table;
+	font-size: 20px;
+	text-align:center;
+	background-color:white;
+}
+#loadDiv span {
+	display:table-cell;
+	vertical-align:middle;
+}
+
+body .mblProgContainer {
+	top:45%;
+	height: 45px;
+	width: 140px;
+	margin-left:-70px;
+	background-color: #2A2A28;
+	border-style: solid;
+	border-width: 2px;
+	border-color: #666666;
+	border-radius: 0.4em;
+	-webkit-border-radius: 0.4em;
+	-moz-border-radius: 0.4em;
+}
+
+body .mblProgContainer > div {
+	height: 100%;
+	width: 100%;
+	line-height: 45px;
+	vertical-align: middle;
+	font-size: 20px;
+	color: #c2c2c2;
+}
+
+body .mblProg {
+	left: 3px;
+	top: 3px;
+}
+
+body .mblProgContainer > div::after {
+	padding-left: 42px;
+	content: "Updating...";
+}
+
+#jsContent, #htmlContent {
+	padding-left:2px;
+}
+
+@media screen and (max-width: 600px) {
+	#jsContent, #htmlContent {
+		font-size: 14px;
+	}
+}
+
+.hidden {
+	display:none;
+}
+
+/*
+div .navPane {
+	width:250px;
+	border-right:1px solid black;
+	background-color: #C5CCD3;
+	z-index:100;
+}
+*/

--- a/tests/mediaQueryLayoutApp/index.html
+++ b/tests/mediaQueryLayoutApp/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+	<head>
+		<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"/>
+		<meta name="apple-mobile-web-app-capable" content="yes" />
+		<title>Media Query Layout App</title>
+		<link type="text/css" href="./css/layoutApp.css" rel="stylesheet" />
+		<script type="text/javascript" src="../../../../dojox/mobile/deviceTheme.js"></script>
+		<script type="text/javascript" src="../../../../dojo/dojo.js" data-dojo-config="parseOnLoad: false,
+				mblHideAddressBar: false,
+				mblAndroidWorkaround: false,
+				mblAlwaysHideAddressBar: false,
+				app: {debugApp: 1},  // set debugApp to log app transtions and view activate/deactivate
+				async: 1">
+		</script>
+		<script>
+			require(["./layoutApp.js"], function(){
+			});
+		</script>
+	</head>
+	<body>
+	</body>
+</html>

--- a/tests/mediaQueryLayoutApp/layoutApp.js
+++ b/tests/mediaQueryLayoutApp/layoutApp.js
@@ -1,0 +1,58 @@
+require(["dojo/_base/window","dojox/app/main", "dojox/json/ref", "dojo/text!./config.json", "dojo/sniff"],
+	function(win, Application, jsonRef, config, has){
+	win.global.modelApp = {};
+	modelApp.names = {
+		identifier: "id",
+		items: [{
+			"id": "1",
+			"Serial": "360324",
+			"First": "John",
+			"Last": "Doe",
+			"Email": "jdoe@us.ibm.com",
+			"ShipTo": {
+				"Street": "123 Valley Rd",
+				"City": "Katonah",
+				"State": "NY",
+				"Zip": "10536"
+			},
+			"BillTo": {
+				"Street": "17 Skyline Dr",
+				"City": "Hawthorne",
+				"State": "NY",
+				"Zip": "10532"
+			}
+		}]
+	};
+	modelApp.repeatData = [{
+		"First": "Chad",
+		"Last": "Chapman",
+		"Location": "CA",
+		"Office": "1278",
+		"Email": "c.c@test.com",
+		"Tel": "408-764-8237",
+		"Fax": "408-764-8228"
+	}, {
+		"First": "Irene",
+		"Last": "Ira",
+		"Location": "NJ",
+		"Office": "F09",
+		"Email": "i.i@test.com",
+		"Tel": "514-764-6532",
+		"Fax": "514-764-7300"
+	}, {
+		"First": "John",
+		"Last": "Jacklin",
+		"Location": "CA",
+		"Office": "6701",
+		"Email": "j.j@test.com",
+		"Tel": "408-764-1234",
+		"Fax": "408-764-4321"
+	}];
+	var config = jsonRef.fromJson(config);
+	// on IE use the HistoryHash controller instead of the History controller.
+	//console.log("has(ie)="+has("ie"));
+	config.controllers[0] = has("ie") ? "dojox/app/controllers/HistoryHash" : "dojox/app/controllers/History";		
+	//console.log("config.controllers[0]="+config.controllers[0]);
+	Application(config);
+	
+});

--- a/tests/mediaQueryLayoutApp/layoutApp.profile.js
+++ b/tests/mediaQueryLayoutApp/layoutApp.profile.js
@@ -1,0 +1,13 @@
+var profile = {
+	resourceTags:{
+		declarative: function(filename){
+	 		return /\.html?$/.test(filename); // tags any .html or .htm files as declarative
+	 	},
+		amd: function(filename){
+			return /\.js$/.test(filename);
+		},
+		copyOnly: function(filename, mid){
+			return mid == "layoutApp/build.profile";
+		}
+	}
+};

--- a/tests/mediaQueryLayoutApp/package.json
+++ b/tests/mediaQueryLayoutApp/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "layoutApp",
+	"dojoBuild": "layoutApp.profile.js"
+}

--- a/tests/mediaQueryLayoutApp/templates/TestInfo.html
+++ b/tests/mediaQueryLayoutApp/templates/TestInfo.html
@@ -1,0 +1,29 @@
+<div class="view mblView">
+
+	<script type="dojo/require">at: "dojox/mvc/at"</script>
+
+	<!--<div data-dojo-type="dojox/mobile/ScrollableView"> -->
+	<div>
+		<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Test Info for this test.</h2>
+
+		<div>
+			<div class="field-title">This has been setup to use a custom layout controller (CssLayout) with media queries.</div>
+			<div class="field-title">The CssLayout layout controller uses css to size the views, it does not call resize on the views, this is to improve performance during orientation changes.</div>
+			<br>
+			<div class="field-title">On a desktop you can make the window smaller and the navigation area will be hidden and the Back button will display when the screen gets less than max-width: 560px.</div>
+			<br>
+			<div class="field-title">On a phone or tablet the Naviagtion will be hidden in portrait orientation and shown in landscape orientation.</div>
+			<br><br>
+			<div class="field-title">More work needs to be done for the following.</div>
+			<br>
+			<div class="field-title">1) When the Navigation area is hidden and Back button takes you to the Configuration (Navigation) view, and then the screen is rotated or enlarged to show the navigation area on the left, the configuration (navigation view) in the center should be transitioned to a different view, either the previous view or some default view.</div>
+			<br>
+			<div class="field-title">2) I think with more work on the css and html we should be able to have the center views display taking the full available width, without having to call resize.</div>
+			<div class="field-title">3) There are some cases where a view needs to have resize called, this should be an option set on the config to indicate that a call resize is required for a view.</div>
+			<div class="field-title">4) There are problems getting things to display without the resize calls when using a dojox/mobile/ScrollableView.</div>
+			<div class="field-title">5) I had trouble getting TestInfo to display as the defaultView until I created a TestInfo.js and set it up as the defintion.</div>
+			<div class="field-title">6) The back button can stay displayed after the Nav is hidden, go Back to nav, select a view, and then resize bigger.</div>
+			<br>
+		</div>
+	</div>
+</div>

--- a/tests/mediaQueryLayoutApp/templates/centerNavigation.html
+++ b/tests/mediaQueryLayoutApp/templates/centerNavigation.html
@@ -1,0 +1,23 @@
+<div>
+	<!-- center -->
+	<div>
+
+		<div>
+		<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Navigation</h2>
+			<ul data-dojo-type="dojox/mobile/RoundRectList" data-app-constraint="center">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'header+navigation+TestInfo',target:'header+navigation+TestInfo',url:'#header+navigation+TestInfo'}">
+					Test Information
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'header+navigation+simple',target:'header+navigation+simple',url:'#header+navigation+simple'}">
+					Simple Data Binding
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'header+navigation+repeat',target:'header+navigation+repeatList',url:'#header+navigation+repeatList'}">
+					Repeat Data Binding
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'header+navigation+generate',target:'header+navigation+generate',url:'#header+navigation+generate'}">
+					Simple Form Generate
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>

--- a/tests/mediaQueryLayoutApp/templates/generate.html
+++ b/tests/mediaQueryLayoutApp/templates/generate.html
@@ -1,0 +1,47 @@
+<div id="generate" class="view mblView">
+	<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Simple Form Generate Example</h2>
+	<div data-dojo-type="dojox/mobile/ScrollableView">
+		<div id="main">
+			<div id="mainContent" class="generate-maincontent">
+				<div id="outerModelArea">
+					<h3 data-dojo-type="dojox/mobile/RoundRectCategory">Model</h3>
+					<div class="generate-textarea-row">
+						<textarea class="generate-textarea-cell" data-dojo-type="dojox/mobile/TextArea" id="modelArea" style="width: 300px; height: 300px;">
+{
+    "Serial": "11111",
+    "First": "John",
+    "Last": "Doe",
+    "Email": "jdoe@example.com",
+    "Phones": [
+        {
+            "Office": "111-111-1111"
+        },
+        {
+            "Mobile": "222-222-2222"
+        }
+    ]
+}
+						</textarea>
+					</div>
+					<div class="fieldset">
+						<button id="generate1" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+							Generate Form
+						</button>
+					</div>
+				</div>
+				<div id="viewArea" style="display:none">
+					<h3 data-dojo-type="dojox/mobile/RoundRectCategory">Generated View</h3>
+					<div class="fieldset">
+						<div id="view" data-dojo-type="dojox/mvc/Generate">
+						</div>
+					</div>
+					<div class="fieldset">
+						<button id="updateModel" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+							Update Model
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/tests/mediaQueryLayoutApp/templates/header.html
+++ b/tests/mediaQueryLayoutApp/templates/header.html
@@ -1,0 +1,17 @@
+<div>
+	<!-- top -->
+<!--	<h1 data-dojo-type="dojox/mobile/Heading" back="Back" data-dojo-props='label:"Media Query Layout App"' data-app-constraint="top"></h1> -->
+	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Layout App", fixed:"top"'>
+		<span class="mblToolBarButton mblToolBarButtonHasLeftArrow" tabindex="0" id="headerBackButton" 
+			widgetid="headerBackButton">
+			<span class="mblToolBarButtonArrow mblToolBarButtonLeftArrow mblColorDefault mblColorDefault45"></span>
+			<span class="mblToolBarButtonBody mblColorDefault"><table cellpadding="0" cellspacing="0" border="0" class="mblToolBarButtonText">
+				<tbody><tr>
+					<td class="mblToolBarButtonIcon"></td>
+					<td class="mblToolBarButtonLabel">Back</td>
+				</tr></tbody></table>
+			</span>
+		</span>
+	</h1>
+	
+</div>

--- a/tests/mediaQueryLayoutApp/templates/navigation.html
+++ b/tests/mediaQueryLayoutApp/templates/navigation.html
@@ -1,0 +1,27 @@
+<div class="navPane">
+	<!-- left -->
+	<div data-dojo-type="dojox/app/widgets/Container" id="NavWidId" class="navPane left" data-app-constraint="left">
+
+	<!-- <div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" data-dojo-props="scrollable:true">  -->
+		<div>
+		<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Navigation</h2>
+			<ul data-dojo-type="dojox/mobile/RoundRectList" data-app-constraint="center">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'header+navigation+TestInfo',target:'header+navigation+TestInfo',url:'#header+navigation+TestInfo'}">
+					Test Information
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'header+navigation+simple',target:'header+navigation+simple',url:'#header+navigation+simple'}">
+					Simple Data Binding
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'header+navigation+repeat',target:'header+navigation+repeatList',url:'#header+navigation+repeatList'}">
+					Repeat Data Binding
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'header+navigation+generate',target:'header+navigation+generate',url:'#header+navigation+generate'}">
+					Simple Form Generate
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" transitionOptions="{title:'header+navigation+centerNavigation',target:'header+navigation+centerNavigation',url:'#header+navigation+centerNavigation'}">
+					Center Navigation View
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>

--- a/tests/mediaQueryLayoutApp/templates/repeat.html
+++ b/tests/mediaQueryLayoutApp/templates/repeat.html
@@ -1,0 +1,24 @@
+<div class="view mblView">
+	<script type="dojo/require">at: "dojox/mvc/at"</script>
+   	<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Repeat Data Binding Example</h2>
+ 
+    <form name="repeatTestForm" id="repeatTestForm">    
+    	<div class="field-title">Search Results</div>
+        <div id="repeatWidget" class="fieldset" data-dojo-type="dojox/mvc/Repeat" 
+        	data-dojo-props="exprchar: '#', children: this.loadedModels.repeatmodels.model" >
+           <div class="row">            
+                    <input data-dojo-type="dojox/mobile/TextBox"
+                        id="nameInput#{this.index}" data-dojo-props="value: at('rel:#{this.index}','First')" placeHolder="First Name"></input>
+                    <button type="button" id="detail#{this.index}" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+                        Details
+                    </button>
+                    <button type="button" id="insert#{this.index}" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+                        +
+                    </button>
+                    <button type="button" id="delete#{this.index}" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+                        -
+                    </button>
+			</div>
+        </div>
+	</form>
+</div>

--- a/tests/mediaQueryLayoutApp/templates/repeatDetails.html
+++ b/tests/mediaQueryLayoutApp/templates/repeatDetails.html
@@ -1,0 +1,48 @@
+<div class="view mblView">
+	<script type="dojo/require">at: "dojox/mvc/at"</script>
+    <h4 data-dojo-type="dojox/mobile/Heading" back="Back">Repeat Details</h4>
+   	<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory"  back="Back" style="height: 32px;" data-app-constraint="top">Repeat Data Binding Example</h2>
+    
+    <form name="repeatTestForm" id="repeatTestForm">    
+		<div data-dojo-type="dojox/mvc/Group" 
+			data-dojo-props="target: at(this.loadedModels.repeatmodels, 'cursor')">
+					<div class="field-title">
+						<div style="display: inline-block;" id="detailsBanner">Details for selected index:</div>
+						<span class="cell" id="indexOutput"
+							data-dojo-type="dojox/mvc/Output"
+							data-dojo-props="value: at(this.loadedModels.repeatmodels, 'cursorIndex')"></span>
+					</div>
+					<table id="table" cellspacing="10"  style="width: 100%">
+						<tr>
+							<td style="width: 100px;" class="layout">First Name</td>
+							<td class="layout">							
+								<input  id="firstInput" data-dojo-type="dojox/mobile/TextBox" 
+									data-dojo-props="value: at('rel:', 'First'), placeholder:'First Name'">
+							</td>
+						</tr>
+						<tr>
+							<td style="width: 100px;" class="layout">Last Name</td>
+							<td class="layout">
+								<input id="lastInput" data-dojo-type="dojox/mobile/TextBox"
+									 
+									data-dojo-props="placeholder:'Last Name', value: at('rel:', 'Last')">
+							</td>
+						</tr>
+						<tr>
+							<td style="width: 100px;" class="layout">Email</td>
+							<td class="layout">
+								<input  id="emailInput2" data-dojo-type="dojox/mobile/TextBox"
+									data-dojo-props="value: at('rel:', 'Email'), placeholder:'Email'">
+							</td>
+						</tr>
+						<tr>
+							<td style="width: 100px;" class="layout">Telephone</td>
+							<td class="layout">
+								<input  id="telInput" data-dojo-type="dojox/mobile/TextBox"
+									data-dojo-props="value: at('rel:', 'Tel'), placeholder:'Telephone'">
+							</td>
+						</tr>
+					</table>
+		</div>
+		</form>
+</div>

--- a/tests/mediaQueryLayoutApp/templates/simple.html
+++ b/tests/mediaQueryLayoutApp/templates/simple.html
@@ -1,0 +1,90 @@
+<div id="settings" class="view mblView">
+	<script type="dojo/require">at: "dojox/mvc/at"</script>
+	<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Simple Data Binding Example</h2>
+	
+		<form name="testForm" id="testForm">
+			<div class="field-title">
+				Ship to - Bill to Address
+			</div>
+			<div class="fieldset" data-dojo-type="dojox/mvc/Group" data-dojo-props="target: at(this.loadedModels.names, 'model')">
+				<div data-dojo-type="dojox/mvc/Group" data-dojo-props="target: at('rel:', 0)">
+					<table id="table" cellspacing="10" style="width: 100%">
+						<tr>
+							<td style="width: 100px;" class="layout">
+								First
+							</td>
+							<td class="layout">
+								<input id="firstInput1" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'First'), placeholder:'First'">
+							</td>
+						</tr>
+						<tr>
+							<td style="width: 100px;" class="layout">
+								Last Name
+							</td>
+							<td class="layout">
+								<input id="lastInput1" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="placeholder:'Last Name', value: at('rel:', 'Last')">
+							</td>
+						</tr>
+						<tr>
+							<td style="width: 100px;" class="layout">
+								Email
+							</td>
+							<td class="layout">
+								<input id="emailInput1" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'Email'), placeholder:'Email'">
+							</td>
+						</tr>
+					</table>
+					<div class="spacer">
+					</div>
+					<button id="shipto" type="button" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+						Ship To
+					</button>
+					<button id="billto" type="button" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+						Bill To
+					</button>
+					<br/>
+					<div class="fieldset" id="addrGroup" data-dojo-type="dojox/mvc/Group" data-dojo-props="target: at('rel:','ShipTo')">
+						<table id="table" cellspacing="10" style="width: 100%">
+							<tr>
+								<td style="width: 100px;" class="layout">
+									Street
+								</td>
+								<td class="layout">
+									<input id="streetInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'Street'), placeholder:'Street'">
+								</td>
+							</tr>
+							<tr>
+								<td style="width: 100px;" class="layout">
+									City
+								</td>
+								<td class="layout">
+									<input id="cityInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="placeholder:'City', value: at('rel:', 'City')">
+								</td>
+							</tr>
+							<tr>
+								<td style="width: 100px;" class="layout">
+									State
+								</td>
+								<td class="layout">
+									<input id="StateInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'State'), placeholder:'State'">
+								</td>
+							</tr>
+							<tr>
+								<td style="width: 100px;" class="layout">
+									State
+								</td>
+								<td class="layout">
+									<input id="ZipInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'Zip'), placeholder:'Zip Code'">
+								</td>
+							</tr>
+						</table>
+					</div>
+				</div>
+			</div>
+			<div class="spacer">
+			</div>
+			<button id="reset1" type="button" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+				Reset
+			</button>
+		</form>
+</div>

--- a/tests/mediaQueryLayoutApp/views/TestInfo.js
+++ b/tests/mediaQueryLayoutApp/views/TestInfo.js
@@ -1,0 +1,58 @@
+define(["dojo/dom", "dojo/dom-style", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mobile/TransitionEvent", 
+	"dojo/Stateful", "dojox/mvc/parserExtension", "dojox/mvc/sync"],
+function(dom, domStyle, connect, registry, at, TransitionEvent, Stateful, parserExtension, sync){
+	var _connectResults = []; // events connect result
+	var previousView = null;
+
+	navShowingStateful = new Stateful({value: false});
+
+	return {
+		// view init
+		init: function(){
+		},
+		
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			currentModel = this.loadedModels.names;
+			var connectResult;
+			
+			var backButtomDom = dom.byId('headerBackButton');
+			connectResult = connect.connect(backButtomDom, "onclick", function(e){
+				// transition to repeatDetails view with the &cursor=index
+				
+				var transOpts = {
+					title:'header+navigation+centerNavigation',
+					target:'header+navigation+centerNavigation',
+					url:'#header+navigation+centerNavigation'					
+				};
+				new TransitionEvent(e.target, transOpts, e).dispatch(); 
+
+			});
+			
+			
+		},
+
+
+		afterDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		},
+		
+		// repeat view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/mediaQueryLayoutApp/views/centerNavigation.js
+++ b/tests/mediaQueryLayoutApp/views/centerNavigation.js
@@ -1,0 +1,60 @@
+define(["dojo/dom", "dojo/dom-style", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mobile/TransitionEvent", 
+	"dojo/Stateful", "dojox/mvc/parserExtension", "dojox/mvc/sync"],
+function(dom, domStyle, connect, registry, at, TransitionEvent, Stateful, parserExtension, sync){
+	var _connectResults = []; // events connect result
+	var previousView = null;
+
+	navShowingStateful = new Stateful({value: false});
+
+	return {
+		// view init
+		init: function(){
+/*				var navDisplayConverter = {
+					format: function(value){
+						if(value){
+							console.log(value);
+						}
+						return value;
+					}
+				};
+				
+				var navWid = registry.byId("NavWidId");
+				if(navWid){
+					sync(navWid, "display", navShowingStateful, "value",  {
+						bindDirection: sync.from,
+						converter: navDisplayConverter
+					});			
+				}
+*/				
+		},
+		
+		beforeActivate: function(view, data){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			this.previousView = view;
+			var backButtomDom = dom.byId('headerBackButton');
+			domStyle.set(backButtomDom, "display", "none");
+			
+			// setup code to watch for the navigation pane being visible
+			
+		},
+
+		beforeDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var backButtomDom = dom.byId('headerBackButton');
+			domStyle.set(backButtomDom, "display", "block");
+		},
+		
+		// repeat view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/mediaQueryLayoutApp/views/generate.js
+++ b/tests/mediaQueryLayoutApp/views/generate.js
@@ -1,0 +1,83 @@
+define(["dojo/dom", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mobile/TransitionEvent"], 
+function(dom, connect, registry, at, TransitionEvent){
+	var genmodel = null; // generate view data model
+	var _connectResults = []; // events connect result
+
+	var updateModel = function(){
+		dom.byId("modelArea").focus();
+		dom.byId("viewArea").style.display = "none";
+		dom.byId("outerModelArea").style.display = "";
+		registry.byId("modelArea").set("value", (dojo.toJson(genmodel.toPlainObject(), true)));
+	};
+
+	var updateView = function(){
+		try{
+			var modeldata = dojo.fromJson(dom.byId("modelArea").value);
+			genmodel = mvc.newStatefulModel({
+				data: modeldata
+			});
+			registry.byId("view").set("ref", genmodel);
+			dom.byId("outerModelArea").style.display = "none";
+			dom.byId("viewArea").style.display = "";
+		}catch(err){
+			console.error("Error parsing json from model: " + err);
+		}
+	};
+
+	return {
+		init: function(){
+		},
+
+		
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var connectResult;
+
+			connectResult = connect.connect(dom.byId('generate1'), "click", function(){
+				updateView();
+			});
+			_connectResults.push(connectResult);
+
+			connectResult = connect.connect(dom.byId('updateModel'), "click", function(){
+				updateModel();
+			});
+			_connectResults.push(connectResult);
+			
+			var backButtomDom = dom.byId('headerBackButton');
+			connectResult = connect.connect(backButtomDom, "onclick", function(e){
+				// transition to repeatDetails view with the &cursor=index
+				
+				var transOpts = {
+					title:'header+navigation+centerNavigation',
+					target:'header+navigation+centerNavigation',
+					url:'#header+navigation+centerNavigation'					
+				};
+				new TransitionEvent(e.target, transOpts, e).dispatch(); 
+
+			});
+			
+			
+		},
+
+		afterDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		},
+		
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/mediaQueryLayoutApp/views/repeat.js
+++ b/tests/mediaQueryLayoutApp/views/repeat.js
@@ -1,0 +1,119 @@
+define(["dojo/dom", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mobile/TransitionEvent", "dojox/mvc/Repeat", "dojox/mvc/getStateful", "dojox/mvc/Output"],
+function(dom, connect, registry, at, TransitionEvent, Repeat, getStateful, Output){
+	var _connectResults = []; // events connect result
+
+	var repeatmodel = null;	//repeat view data model
+
+	// delete an item
+	var deleteResult = function(index){
+		var nextIndex = repeatmodel.get("cursorIndex");
+		if(nextIndex >= index){
+			nextIndex = nextIndex-1;
+		}
+		repeatmodel.model.splice(index, 1);
+		repeatmodel.set("cursorIndex", nextIndex);		
+	};
+	// show an item detail
+	var setDetailsContext = function(index,e){
+		repeatmodel.set("cursorIndex", index);
+
+		// transition to repeatDetails view with the &cursor=index
+		var transOpts = {
+			title : "repeatDetails",
+			target : "repeatDetails",
+			url : "#repeatDetails", // this is optional if not set it will be created from target   
+			params : {"cursor":index}
+		};
+		new TransitionEvent(e.target, transOpts, e).dispatch(); 
+		
+	};
+	// insert an item
+	var insertResult = function(index, e){
+		if(index<0 || index>repeatmodel.model.length){
+			throw Error("index out of data model.");
+		}
+		if((repeatmodel.model[index].First=="") ||
+			(repeatmodel.model[index+1] && (repeatmodel.model[index+1].First == ""))){
+			return;
+		}
+		var data = {id:Math.random(), "First": "", "Last": "", "Location": "CA", "Office": "", "Email": "", "Tel": "", "Fax": ""};
+		repeatmodel.model.splice(index+1, 0, new getStateful(data));
+		setDetailsContext(index+1, e);
+	};
+	// get index from dom node id
+	var getIndexFromId = function(nodeId, perfix){
+		var len = perfix.length;
+		if(nodeId.length <= len){
+			throw Error("repeate node id error.");
+		}
+		var index = nodeId.substring(len, nodeId.length);
+		return parseInt(index);
+	};
+
+	return {
+		// repeate view init
+		init: function(){
+			repeatmodel = this.loadedModels.repeatmodels;
+		},
+		
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var repeatDom = dom.byId('repeatWidget');
+			var connectResult;
+			connectResult = connect.connect(repeatDom, "button[id^=\"detail\"]:click", function(e){
+				var index = getIndexFromId(e.target.id, "detail");
+				setDetailsContext(index, e);
+			});
+			_connectResults.push(connectResult);
+
+			connectResult = connect.connect(repeatDom, "button[id^=\"insert\"]:click", function(e){
+				var index = getIndexFromId(e.target.id, "insert");
+				insertResult(index, e);
+			});
+			_connectResults.push(connectResult);
+
+			connectResult = connect.connect(repeatDom, "button[id^=\"delete\"]:click", function(e){
+				var index = getIndexFromId(e.target.id, "delete");
+				deleteResult(index);
+			});
+			_connectResults.push(connectResult);
+			
+			var backButtomDom = dom.byId('headerBackButton');
+			connectResult = connect.connect(backButtomDom, "onclick", function(e){
+				// transition to repeatDetails view with the &cursor=index
+				
+				var transOpts = {
+					title:'header+navigation+centerNavigation',
+					target:'header+navigation+centerNavigation',
+					url:'#header+navigation+centerNavigation'					
+				};
+				new TransitionEvent(e.target, transOpts, e).dispatch(); 
+
+			});
+			
+			
+		},
+
+		afterDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		},
+		
+		// repeat view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/mediaQueryLayoutApp/views/repeatDetails.js
+++ b/tests/mediaQueryLayoutApp/views/repeatDetails.js
@@ -1,0 +1,41 @@
+define(["dojo/dom", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mvc/getStateful", "dojox/mvc/Output"],
+function(dom, connect, registry, at, getStateful, Output){
+	var _connectResults = []; // events connect result
+
+	var repeatmodel = null;	//repeat view data model
+
+	// show an item detail
+	var setDetailsContext = function(index){
+		// only set the cursor if it is different and valid
+		if(parseInt(index) != repeatmodel.cursorIndex && parseInt(index) < repeatmodel.model.length){
+			repeatmodel.set("cursorIndex", parseInt(index));
+		}
+	};
+
+	// get index from dom node id
+	var getIndexFromId = function(nodeId, perfix){
+		var len = perfix.length;
+		if(nodeId.length <= len){
+			throw Error("repeate node id error.");
+		}
+		var index = nodeId.substring(len, nodeId.length);
+		return parseInt(index);
+	};
+
+	return {
+		// repeate view init
+		init: function(){
+			repeatmodel = this.loadedModels.repeatmodels;
+		},
+
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			// if this.params["cursor"] is set use it to set the selected Details Context
+			if(this.params["cursor"]){
+				setDetailsContext(this.params["cursor"]);
+			}
+		}
+	}
+});

--- a/tests/mediaQueryLayoutApp/views/simple.js
+++ b/tests/mediaQueryLayoutApp/views/simple.js
@@ -1,0 +1,76 @@
+define(["dojo/dom", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mobile/TransitionEvent"],
+function(dom, connect, registry, at,TransitionEvent){
+	var _connectResults = []; // events connect results
+	var currentModel = null;
+
+	var setRef = function (id, attr){
+		var widget = registry.byId(id);
+		widget.set("target", at("rel:", attr));
+		console.log("setRef done.");
+	};
+	return {
+		// simple view init
+		init: function(){
+		},
+		
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			currentModel = this.loadedModels.names;
+			var connectResult;
+
+			connectResult = connect.connect(dom.byId('shipto'), "click", function(){
+				setRef('addrGroup', 'ShipTo');
+			});
+			_connectResults.push(connectResult);
+
+			connectResult = connect.connect(dom.byId('billto'), "click", function(){
+				setRef('addrGroup', 'BillTo');
+			});
+			_connectResults.push(connectResult);
+
+			connectResult = connect.connect(dom.byId('reset1'), "click", function(){
+				currentModel.reset();
+				console.log("reset done. ");
+			});
+			_connectResults.push(connectResult);
+			
+			var backButtomDom = dom.byId('headerBackButton');
+			connectResult = connect.connect(backButtomDom, "onclick", function(e){
+				// transition to repeatDetails view with the &cursor=index
+				
+				var transOpts = {
+					title:'header+navigation+centerNavigation',
+					target:'header+navigation+centerNavigation',
+					url:'#header+navigation+centerNavigation'					
+				};
+				new TransitionEvent(e.target, transOpts, e).dispatch(); 
+
+			});
+			
+			
+		},
+
+		afterDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		},
+		
+
+		// simple view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/modelApp/views/repeat.js
+++ b/tests/modelApp/views/repeat.js
@@ -80,7 +80,6 @@ function(lang, dom, connect, registry, at, TransitionEvent, Repeat, getStateful,
 			});
 			_connectResults.push(connectResult);
 		},
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp/templates/ListItem-domButtons.html
+++ b/tests/scrollableTestApp/templates/ListItem-domButtons.html
@@ -1,106 +1,106 @@
 <div class="view mblView">
-	<div data-dojo-type="dojox.mobile.ScrollableView">
+	<div data-dojo-type="dojox/mobile/ScrollableView">
 <!--
 			<div data-dojo-type="dojox/mobile/Heading" data-dojo-props='fixed:"top", data-app-constraint="top",
 -->
 		<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='fixed:"top", 
 							label:"Mobile Scrollable Test."'>
-			<span id="mli1back" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+			<span id="mli1back" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 			data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration,ScrollableListSelection', url: '#configuration,ScrollableListSelection', transitionDir: -1}">Back</span>
 		</h1>
 
-		<h2 data-dojo-type="dojox.mobile.RoundRectCategory">Transition Effects</h2>
+		<h2 data-dojo-type="dojox/mobile/RoundRectCategory">Transition Effects</h2>
 
-		<div data-dojo-type="dojox.mobile.RoundRect">
+		<div data-dojo-type="dojox/mobile/RoundRect">
 			header: Mobile Scrollable Test<br>
 			footer: application-footer<br>
 			scrollDir: vertical with 27 items
 		</div>
 
-		<ul data-dojo-type="dojox.mobile.RoundRectList">
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+		<ul data-dojo-type="dojox/mobile/RoundRectList">
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 1
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 2
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 3
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 4
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 5
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 6
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 7
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 8
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 9
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 10
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 11
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 12
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 13
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 14
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 15
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 16
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 17
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 18
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 19
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 20
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 21
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 22
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 23
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 24
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 25
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 26
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 27
 			</li>
 		</ul>
 	</div>
-	<h1 data-dojo-type="dojox.mobile.Heading" data-dojo-props='fixed:"bottom"' style="border-bottom:none;">Application Footer Bar</h1>
+	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='fixed:"bottom"' style="border-bottom:none;">Application Footer Bar</h1>
 
 </div>

--- a/tests/scrollableTestApp/templates/ListItem-domButtons2.html
+++ b/tests/scrollableTestApp/templates/ListItem-domButtons2.html
@@ -1,21 +1,21 @@
 <div class="view mblView">
-	<div data-dojo-type="dojox.mobile.ScrollableView">
-		<h1 data-dojo-type="dojox.mobile.Heading" data-dojo-props='fixed:"top", back:"Back"'>Mobile Scrollable Test.</h1>
-		<ul data-dojo-type="dojox.mobile.RoundRectList" data-dojo-props='variableHeight:true'>
-			<li data-dojo-type="dojox.mobile.ListItem" style="font-size:10px">
+	<div data-dojo-type="dojox/mobile/ScrollableView">
+		<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='fixed:"top", back:"Back"'>Mobile Scrollable Test.</h1>
+		<ul data-dojo-type="dojox/mobile/RoundRectList" data-dojo-props='variableHeight:true'>
+			<li data-dojo-type="dojox/mobile/ListItem" style="font-size:10px">
 				1. <a href="#" class="lnk">Dojo: Traditional Karate-do Spirit</a><br>
 				Sarah Connor Hardcover<br>
 				Eligible for FREE Super Saver Shipping<br>
 				<span style="color:red">$14.50 (50%)</span> In Stock<br>
 				# (531)
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" style="font-size:10px">
+			<li data-dojo-type="dojox/mobile/ListItem" style="font-size:10px">
 				2. <a href="#" class="lnk">Japanese Martial Arts Dojo</a><br>
 				Martin Parker Hardcover<br>
 				<span style="color:red">$14.00 (60%)</span> In Stock<br>
 				# (173)
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" style="font-size:10px">
+			<li data-dojo-type="dojox/mobile/ListItem" style="font-size:10px">
 				3. <a href="#" class="lnk">Total Solar Eclipse</a><br>
 				Steven Young Hardcover<br>
 				Get it by Mar. 2 if you order in the next <span style="color:green"><b>16 hours</b></span><br>
@@ -23,12 +23,12 @@
 				<span style="color:red">$9.50 (62%)</span> In Stock<br>
 				# (1199)
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" style="font-size:10px">
+			<li data-dojo-type="dojox/mobile/ListItem" style="font-size:10px">
 				4. <a href="#" class="lnk">The History of Java Coffee</a><br>
 				Marco Rodriguez Hardcover<br>
 				<span style="color:blue">Not Available</span>
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" style="font-size:10px">
+			<li data-dojo-type="dojox/mobile/ListItem" style="font-size:10px">
 				5. <a href="#" class="lnk">The Principles of Spider's Web</a><br>
 				Melissa Morgan Hardcover<br>
 				Eligible for FREE Super Saver Shipping<br>
@@ -37,6 +37,6 @@
 			</li>
 		</ul>
 	</div>
-	<h1 data-dojo-type="dojox.mobile.Heading" data-dojo-props='fixed:"bottom"' style="border-bottom:none;">Application Footer Bar</h1>
+	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='fixed:"bottom"' style="border-bottom:none;">Application Footer Bar</h1>
 
 </div>

--- a/tests/scrollableTestApp/templates/Scrollable1.html
+++ b/tests/scrollableTestApp/templates/Scrollable1.html
@@ -1,7 +1,7 @@
 <div class="view mblView">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List One"' data-app-constraint="top">
-		<span id="sc1back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+		<span id="sc1back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration,ScrollableListSelection', url: '#configuration,ScrollableListSelection', transitionDir: -1}">Back</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc1insert1x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">1</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc1insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">10</span>
@@ -23,7 +23,6 @@
 					data-mvc-child-type="dojox/mvc/Templated"
 					data-mvc-child-mixins="dojox/mobile/ListItem"
 					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
 							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
 							onClick: function(){setDetailsContext(this.indexAtStartup);}">					
 					<script type="dojox/mvc/InlineTemplate">
@@ -33,6 +32,7 @@
 								                 onClick: function(e){ /*console.log(this); console.log(this.indexAtStartup);console.log(e);*/
 								                 	        removeScrollableItem(this.indexAtStartup); return false; }"
 								style="float: left; color: white; background-color: transparent; background-image: none; border: none;"></div>
+							<div data-dojo-type="dojox/mvc/Output" data-dojo-props="value: at('rel:', 'First')"></div>	
 						</li>
 					</script>
 				</ul>

--- a/tests/scrollableTestApp/templates/Scrollable1P.html
+++ b/tests/scrollableTestApp/templates/Scrollable1P.html
@@ -1,7 +1,7 @@
 <div class="view mblView">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List OneP"' data-app-constraint="top">
-		<span id="sc1back1P" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+		<span id="sc1back1P" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration,ScrollableListSelection', url: '#configuration,ScrollableListSelection', transitionDir: -1}">Back</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc1insert1xP" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">1</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc1insert10xP" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">10</span>

--- a/tests/scrollableTestApp/templates/Scrollable2.html
+++ b/tests/scrollableTestApp/templates/Scrollable2.html
@@ -2,7 +2,7 @@
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 
 	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List Two"' data-app-constraint="top">
-		<span id="sc2back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+		<span id="sc2back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration,ScrollableListSelection', url: '#configuration,ScrollableListSelection', transitionDir: -1}">Back</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc2insert1x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">1</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc2insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">10</span>
@@ -22,7 +22,6 @@
 					data-mvc-child-type="dojox/mvc/Templated"
 					data-mvc-child-mixins="dojox/mobile/ListItem"
 					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
 							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
 							onClick: function(){setDetailsContext(this.indexAtStartup);}">
 					<script type="dojox/mvc/InlineTemplate">
@@ -32,6 +31,7 @@
 													onClick: function(e){ /*console.log(this); console.log(this.indexAtStartup);console.log(e);*/
 																		removeScrollableItem(this.indexAtStartup); return false; }"
 								style="float: left; color: white; background-color: transparent; background-image: none; border: none;"></div>
+							<div data-dojo-type="dojox/mvc/Output" data-dojo-props="value: at('rel:', 'First')"></div>	
 						</li>
 					</script>
 				</ul>

--- a/tests/scrollableTestApp/templates/Scrollable3.html
+++ b/tests/scrollableTestApp/templates/Scrollable3.html
@@ -2,7 +2,7 @@
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 
 	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List Three"' data-app-constraint="top">
-		<span id="sc3back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+		<span id="sc3back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration,ScrollableListSelection', url: '#configuration,ScrollableListSelection', transitionDir: -1}">Back</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc3insert1x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">1</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc3insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">10</span>
@@ -24,7 +24,6 @@
 					data-mvc-child-type="dojox/mvc/Templated"
 					data-mvc-child-mixins="dojox/mobile/ListItem"
 					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
 							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
 							onClick: function(){setDetailsContext(this.indexAtStartup);}">
 					<script type="dojox/mvc/InlineTemplate">
@@ -34,6 +33,7 @@
 													onClick: function(e){ /*console.log(this); console.log(this.indexAtStartup);console.log(e);*/
 																		removeScrollableItem(this.indexAtStartup); return false; }"
 								style="float: left; color: white; background-color: transparent; background-image: none; border: none;"></div>
+							<div data-dojo-type="dojox/mvc/Output" data-dojo-props="value: at('rel:', 'First')"></div>	
 						</li>
 					</script>
 				</ul>

--- a/tests/scrollableTestApp/templates/Scrollable4.html
+++ b/tests/scrollableTestApp/templates/Scrollable4.html
@@ -1,10 +1,10 @@
 <div class="view mblView">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 
-	<div data-dojo-type="dojox.mobile.ScrollableView">
+	<div data-dojo-type="dojox/mobile/ScrollableView">
 
 	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List Four", fixed:"top"'>
-		<span id="sc4back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+		<span id="sc4back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration,ScrollableListSelection', url: '#configuration,ScrollableListSelection', transitionDir: -1}">Back</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc4insert1x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">1</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc4insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">10</span>
@@ -24,7 +24,6 @@
 					data-mvc-child-type="dojox/mvc/Templated"
 					data-mvc-child-mixins="dojox/mobile/ListItem"
 					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
 							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
 							onClick: function(){setDetailsContext(this.indexAtStartup);}">
 					<script type="dojox/mvc/InlineTemplate">
@@ -34,6 +33,7 @@
 												onClick: function(e){ /*console.log(this); console.log(this.indexAtStartup);console.log(e);*/
 																		removeScrollableItem(this.indexAtStartup); return false; }"
 								style="float: left; color: white; background-color: transparent; background-image: none; border: none;"></div>
+							<div data-dojo-type="dojox/mvc/Output" data-dojo-props="value: at('rel:', 'First')"></div>	
 						</li>
 					</script>
 				</ul>

--- a/tests/scrollableTestApp/templates/Scrollable5.html
+++ b/tests/scrollableTestApp/templates/Scrollable5.html
@@ -1,10 +1,10 @@
 <div class="view mblView">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 
-	<div data-dojo-type="dojox.mobile.ScrollableView">
+	<div data-dojo-type="dojox/mobile/ScrollableView">
 
 	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List Five", fixed:"top"'>
-		<span id="sc5back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+		<span id="sc5back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration,ScrollableListSelection', url: '#configuration,ScrollableListSelection', transitionDir: -1}">Back</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc5insert1x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">1</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc5insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">10</span>
@@ -24,7 +24,6 @@
 					data-mvc-child-type="dojox/mvc/Templated"
 					data-mvc-child-mixins="dojox/mobile/ListItem"
 					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
 							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
 							onClick: function(){setDetailsContext(this.indexAtStartup);}">
 					<script type="dojox/mvc/InlineTemplate">
@@ -34,6 +33,7 @@
 												onClick: function(e){ /*console.log(this); console.log(this.indexAtStartup);console.log(e);*/
 																removeScrollableItem(this.indexAtStartup); return false; }"
 								style="float: left; color: white; background-color: transparent; background-image: none; border: none;"></div>
+							<div data-dojo-type="dojox/mvc/Output" data-dojo-props="value: at('rel:', 'First')"></div>	
 						</li>
 					</script>
 				</ul>

--- a/tests/scrollableTestApp/templates/TestInfo.html
+++ b/tests/scrollableTestApp/templates/TestInfo.html
@@ -2,11 +2,11 @@
 
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 
-	<div data-dojo-type="dojox.mobile.ScrollableView">
+	<div data-dojo-type="dojox/mobile/ScrollableView">
 
 		<h1 id="tst1WrapperA" style="visibility:hidden"
 			data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Test Info for Scrollable tests.", fixed:"top"'>
-			<span id="ti1back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left"
+			<span id="ti1back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left"
 				data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration,ScrollableListSelection', url: '#configuration,ScrollableListSelection', transitionDir: -1}">Back</span>
 		</h1>
 
@@ -20,7 +20,7 @@
 			<br><br>
 			<div class="field-title">Note that the tests which use <b>dojox/app/widgets/Container with scrollable:true</b> should use use headers or footers with data-app-constraint="top" or data-app-constraint="bottom" and they should not use headers and footers with fixed:'top' and fixed:'bottom'.</div>
 			<br>
-			<div class="field-title">Note that the tests which use <b>dojox.mobile.ScrollableView</b> should use headers and footers with fixed:'top' and fixed:'bottom' and they should not use headers or footers with data-app-constraint="top" or data-app-constraint="bottom".</div>
+			<div class="field-title">Note that the tests which use <b>dojox/mobile/ScrollableView</b> should use headers and footers with fixed:'top' and fixed:'bottom' and they should not use headers or footers with data-app-constraint="top" or data-app-constraint="bottom".</div>
 			<br>
 			<div class="field-title"><b>Problems with Scrollable List 4 and 5, and the Dojox Mobile Test:</b></div>
 			<div class="field-title">On a phone or tablet also have problems after an  couple of orientation changes, it gets to where you can not scroll to the last items, and after an orientation change from landscape to portrait mode the window size is too small.</div>

--- a/tests/scrollableTestApp/templates/configuration/ScrollableListSelection.html
+++ b/tests/scrollableTestApp/templates/configuration/ScrollableListSelection.html
@@ -53,7 +53,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable4', url: '#Scrollable4'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list Four</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
+					Uses dojox/mobile/ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
@@ -61,7 +61,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable5', url: '#Scrollable5'}">
 					<div class="textBox">
 					<div class="subject">Scrollable list Five</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
+					Uses dojox/mobile/ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"

--- a/tests/scrollableTestApp/templates/repeatDetails.html
+++ b/tests/scrollableTestApp/templates/repeatDetails.html
@@ -1,6 +1,6 @@
 <div class="view mblView">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
-	<h1 data-dojo-type="dojox.mobile.Heading" back="Back">Repeat Details</h1>
+	<h1 data-dojo-type="dojox/mobile/Heading" back="Back">Repeat Details</h1>
 	<form name="repeatTestForm" id="repeatTestForm">    
 		<div data-dojo-type="dojox/mvc/Group" 
 			data-dojo-props="target: at(this.loadedModels.repeatmodels, 'cursor')">
@@ -14,14 +14,14 @@
 						<tr>
 							<td style="width: 100px;" class="layout">First Name</td>
 							<td class="layout">							
-								<input  id="firstInput" data-dojo-type="dojox.mobile.TextBox" 
+								<input  id="firstInput" data-dojo-type="dojox/mobile/TextBox" 
 									data-dojo-props="value: at('rel:', 'First'), placeholder:'First Name'">
 							</td>
 						</tr>
 						<tr>
 							<td style="width: 100px;" class="layout">Last Name</td>
 							<td class="layout">
-								<input id="lastInput" data-dojo-type="dojox.mobile.TextBox"
+								<input id="lastInput" data-dojo-type="dojox/mobile/TextBox"
 									 
 									data-dojo-props="placeholder:'Last Name', value: at('rel:', 'Last')">
 							</td>
@@ -29,14 +29,14 @@
 						<tr>
 							<td style="width: 100px;" class="layout">Email</td>
 							<td class="layout">
-								<input  id="emailInput2" data-dojo-type="dojox.mobile.TextBox"
+								<input  id="emailInput2" data-dojo-type="dojox/mobile/TextBox"
 									data-dojo-props="value: at('rel:', 'Email'), placeholder:'Email'">
 							</td>
 						</tr>
 						<tr>
 							<td style="width: 100px;" class="layout">Telephone</td>
 							<td class="layout">
-								<input  id="telInput" data-dojo-type="dojox.mobile.TextBox"
+								<input  id="telInput" data-dojo-type="dojox/mobile/TextBox"
 									data-dojo-props="value: at('rel:', 'Tel'), placeholder:'Telephone'">
 							</td>
 						</tr>

--- a/tests/scrollableTestApp/templates/tablet/ViewScrollableLists.html
+++ b/tests/scrollableTestApp/templates/tablet/ViewScrollableLists.html
@@ -52,7 +52,7 @@
 				transitionOptions: {title:'List',target: 'Scrollable4', url: '#Scrollable4'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list Four</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
+					Uses dojox/mobile/ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
@@ -60,7 +60,7 @@
 				transitionOptions: {title:'List',target: 'Scrollable5', url: '#Scrollable5'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list Five</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
+					Uses dojox/mobile/ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"

--- a/tests/scrollableTestApp/views/ListItem-domButtons.js
+++ b/tests/scrollableTestApp/views/ListItem-domButtons.js
@@ -12,9 +12,6 @@ function(dom, domStyle, connect, registry, at, TransitionEvent, Repeat, getState
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId("mli1back") && this.app.isTablet){ 
 				domStyle.set(dom.byId("mli1back"), "visibility", "hidden"); // hide the back button in tablet mode
 			}

--- a/tests/scrollableTestApp/views/ListItem-domButtons2.js
+++ b/tests/scrollableTestApp/views/ListItem-domButtons2.js
@@ -84,9 +84,6 @@ function(dom, domStyle, connect, registry, at, TransitionEvent, Repeat, getState
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId("back3r") && this.app.isTablet){ 
 				domStyle.set(dom.byId("back3r"), "visibility", "hidden"); // hide the back button in tablet mode
 			}

--- a/tests/scrollableTestApp/views/Scrollable1.js
+++ b/tests/scrollableTestApp/views/Scrollable1.js
@@ -115,9 +115,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -137,7 +134,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp/views/Scrollable1P.js
+++ b/tests/scrollableTestApp/views/Scrollable1P.js
@@ -82,18 +82,6 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 		// datamodel: dojox/mvc/EditStoreRefListController
 		//		The EditStoreRefListController whose model holds the items for the selected list.
 		//
-	/*
-	 					data-dojo-type="dojox/mobile/RoundRectList"
-					data-dojo-mixins="dojox/mvc/WidgetList,dojox/mvc/_InlineTemplateMixin"
-					data-dojo-props="children: this.loadedModels.repeatmodels.model"
-					data-mvc-child-type="dojox/mvc/Templated"
-					data-mvc-child-mixins="dojox/mobile/ListItem"
-					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
-							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
-							onClick: function(){setDetailsContext(this.indexAtStartup);}">					
- 
-	 */	
 		if(!roundRectWidList){
 			var clz = declare([WidgetList, RoundRectList], {});
 			roundRectWidList = new clz({
@@ -111,8 +99,6 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 				},
 				templateString: RoundRectWidListTemplate
 			});
-			//roundRectWidList.placeAt(dom.byId("list_container"));
-			//roundRectWidList.placeAt(dom.byId("list_type").parentNode);
 			roundRectWidList.placeAt(dom.byId("addWidgetHere"));
 			roundRectWidList.startup();
 		}else{
@@ -121,7 +107,6 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 	};
 
 	return {
-		// repeate view init
 		init: function(){
 			app = this.app;
 
@@ -169,9 +154,6 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -193,7 +175,6 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp/views/Scrollable2.js
+++ b/tests/scrollableTestApp/views/Scrollable2.js
@@ -111,9 +111,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -124,7 +121,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp/views/Scrollable3.js
+++ b/tests/scrollableTestApp/views/Scrollable3.js
@@ -111,9 +111,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -124,7 +121,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp/views/Scrollable4.js
+++ b/tests/scrollableTestApp/views/Scrollable4.js
@@ -111,9 +111,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -124,7 +121,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp/views/Scrollable5.js
+++ b/tests/scrollableTestApp/views/Scrollable5.js
@@ -111,9 +111,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -124,7 +121,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp/views/TestInfo.js
+++ b/tests/scrollableTestApp/views/TestInfo.js
@@ -19,9 +19,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -39,7 +36,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp2/templates/ListItem-domButtons.html
+++ b/tests/scrollableTestApp2/templates/ListItem-domButtons.html
@@ -1,106 +1,106 @@
 <div class="view mblView">
-	<div data-dojo-type="dojox.mobile.ScrollableView">
+	<div data-dojo-type="dojox/mobile/ScrollableView">
 <!--
 			<div data-dojo-type="dojox/mobile/Heading" data-dojo-props='fixed:"top", data-app-constraint="top",
 -->
 		<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='fixed:"top", 
 							label:"Mobile Scrollable Test."'>
-			<span id="mli1back" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
-			data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration', url: '#configuration', transitionDir: -1}">Back</span>
+			<span id="mli1back" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
+			data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration,ScrollableListSelection', url: '#configuration,ScrollableListSelection', transitionDir: -1}">Back</span>
 		</h1>
 
-		<h2 data-dojo-type="dojox.mobile.RoundRectCategory">Transition Effects</h2>
+		<h2 data-dojo-type="dojox/mobile/RoundRectCategory">Transition Effects</h2>
 
-		<div data-dojo-type="dojox.mobile.RoundRect">
+		<div data-dojo-type="dojox/mobile/RoundRect">
 			header: Mobile Scrollable Test<br>
 			footer: application-footer<br>
 			scrollDir: vertical with 27 items
 		</div>
 
-		<ul data-dojo-type="dojox.mobile.RoundRectList">
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+		<ul data-dojo-type="dojox/mobile/RoundRectList">
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 1
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 2
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 3
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 4
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 5
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 6
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 7
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 8
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 9
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-1.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 10
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-2.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 11
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-3.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 12
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-4.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 13
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-5.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 14
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-6.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 15
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 16
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 17
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 18
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 19
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 20
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 21
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 22
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 23
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 24
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-7.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"slide"'>
 				Slide 25
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-8.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"flip"'>
 				Flip 26
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
+			<li data-dojo-type="dojox/mobile/ListItem" data-dojo-props='icon:"../../../mobile/tests/images/i-icon-9.png", transitionOptions: {title:"List",target: "ListItemDomButtons2", url: "#ListItemDomButtons2"}, transition:"fade"'>
 				Fade 27
 			</li>
 		</ul>
 	</div>
-	<h1 data-dojo-type="dojox.mobile.Heading" data-dojo-props='fixed:"bottom"' style="border-bottom:none;">Application Footer Bar</h1>
+	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='fixed:"bottom"' style="border-bottom:none;">Application Footer Bar</h1>
 
 </div>

--- a/tests/scrollableTestApp2/templates/ListItem-domButtons2.html
+++ b/tests/scrollableTestApp2/templates/ListItem-domButtons2.html
@@ -1,21 +1,21 @@
 <div class="view mblView">
-	<div data-dojo-type="dojox.mobile.ScrollableView">
-		<h1 data-dojo-type="dojox.mobile.Heading" data-dojo-props='fixed:"top", back:"Back"'>Mobile Scrollable Test.</h1>
-		<ul data-dojo-type="dojox.mobile.RoundRectList" data-dojo-props='variableHeight:true'>
-			<li data-dojo-type="dojox.mobile.ListItem" style="font-size:10px">
+	<div data-dojo-type="dojox/mobile/ScrollableView">
+		<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='fixed:"top", back:"Back"'>Mobile Scrollable Test.</h1>
+		<ul data-dojo-type="dojox/mobile/RoundRectList" data-dojo-props='variableHeight:true'>
+			<li data-dojo-type="dojox/mobile/ListItem" style="font-size:10px">
 				1. <a href="#" class="lnk">Dojo: Traditional Karate-do Spirit</a><br>
 				Sarah Connor Hardcover<br>
 				Eligible for FREE Super Saver Shipping<br>
 				<span style="color:red">$14.50 (50%)</span> In Stock<br>
 				# (531)
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" style="font-size:10px">
+			<li data-dojo-type="dojox/mobile/ListItem" style="font-size:10px">
 				2. <a href="#" class="lnk">Japanese Martial Arts Dojo</a><br>
 				Martin Parker Hardcover<br>
 				<span style="color:red">$14.00 (60%)</span> In Stock<br>
 				# (173)
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" style="font-size:10px">
+			<li data-dojo-type="dojox/mobile/ListItem" style="font-size:10px">
 				3. <a href="#" class="lnk">Total Solar Eclipse</a><br>
 				Steven Young Hardcover<br>
 				Get it by Mar. 2 if you order in the next <span style="color:green"><b>16 hours</b></span><br>
@@ -23,12 +23,12 @@
 				<span style="color:red">$9.50 (62%)</span> In Stock<br>
 				# (1199)
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" style="font-size:10px">
+			<li data-dojo-type="dojox/mobile/ListItem" style="font-size:10px">
 				4. <a href="#" class="lnk">The History of Java Coffee</a><br>
 				Marco Rodriguez Hardcover<br>
 				<span style="color:blue">Not Available</span>
 			</li>
-			<li data-dojo-type="dojox.mobile.ListItem" style="font-size:10px">
+			<li data-dojo-type="dojox/mobile/ListItem" style="font-size:10px">
 				5. <a href="#" class="lnk">The Principles of Spider's Web</a><br>
 				Melissa Morgan Hardcover<br>
 				Eligible for FREE Super Saver Shipping<br>
@@ -37,6 +37,6 @@
 			</li>
 		</ul>
 	</div>
-	<h1 data-dojo-type="dojox.mobile.Heading" data-dojo-props='fixed:"bottom"' style="border-bottom:none;">Application Footer Bar</h1>
+	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='fixed:"bottom"' style="border-bottom:none;">Application Footer Bar</h1>
 
 </div>

--- a/tests/scrollableTestApp2/templates/Scrollable1.html
+++ b/tests/scrollableTestApp2/templates/Scrollable1.html
@@ -1,7 +1,7 @@
 <div class="view mblView">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List One"' data-app-constraint="top">
-		<span id="sc1back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+		<span id="sc1back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration', url: '#configuration', transitionDir: -1}">Back</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc1insert1x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">1</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc1insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">10</span>
@@ -23,7 +23,6 @@
 					data-mvc-child-type="dojox/mvc/Templated"
 					data-mvc-child-mixins="dojox/mobile/ListItem"
 					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
 							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
 							onClick: function(){setDetailsContext(this.indexAtStartup);}">					
 					<script type="dojox/mvc/InlineTemplate">
@@ -33,6 +32,7 @@
 								                 onClick: function(e){ /*console.log(this); console.log(this.indexAtStartup);console.log(e);*/
 								                 	        removeScrollableItem(this.indexAtStartup); return false; }"
 								style="float: left; color: white; background-color: transparent; background-image: none; border: none;"></div>
+							<div data-dojo-type="dojox/mvc/Output" data-dojo-props="value: at('rel:', 'First')"></div>	
 						</li>
 					</script>
 				</ul>

--- a/tests/scrollableTestApp2/templates/Scrollable2.html
+++ b/tests/scrollableTestApp2/templates/Scrollable2.html
@@ -2,7 +2,7 @@
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 
 	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List Two"' data-app-constraint="top">
-		<span id="sc2back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+		<span id="sc2back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration', url: '#configuration', transitionDir: -1}">Back</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc2insert1x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">1</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc2insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">10</span>
@@ -22,7 +22,6 @@
 					data-mvc-child-type="dojox/mvc/Templated"
 					data-mvc-child-mixins="dojox/mobile/ListItem"
 					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
 							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
 							onClick: function(){setDetailsContext(this.indexAtStartup);}">
 					<script type="dojox/mvc/InlineTemplate">
@@ -32,6 +31,7 @@
 													onClick: function(e){ /*console.log(this); console.log(this.indexAtStartup);console.log(e);*/
 																		removeScrollableItem(this.indexAtStartup); return false; }"
 								style="float: left; color: white; background-color: transparent; background-image: none; border: none;"></div>
+							<div data-dojo-type="dojox/mvc/Output" data-dojo-props="value: at('rel:', 'First')"></div>	
 						</li>
 					</script>
 				</ul>

--- a/tests/scrollableTestApp2/templates/Scrollable3.html
+++ b/tests/scrollableTestApp2/templates/Scrollable3.html
@@ -2,7 +2,7 @@
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 
 	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List Three"' data-app-constraint="top">
-		<span id="sc3back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+		<span id="sc3back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration', url: '#configuration', transitionDir: -1}">Back</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc3insert1x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">1</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc3insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">10</span>
@@ -24,7 +24,6 @@
 					data-mvc-child-type="dojox/mvc/Templated"
 					data-mvc-child-mixins="dojox/mobile/ListItem"
 					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
 							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
 							onClick: function(){setDetailsContext(this.indexAtStartup);}">
 					<script type="dojox/mvc/InlineTemplate">
@@ -34,6 +33,7 @@
 													onClick: function(e){ /*console.log(this); console.log(this.indexAtStartup);console.log(e);*/
 																		removeScrollableItem(this.indexAtStartup); return false; }"
 								style="float: left; color: white; background-color: transparent; background-image: none; border: none;"></div>
+							<div data-dojo-type="dojox/mvc/Output" data-dojo-props="value: at('rel:', 'First')"></div>	
 						</li>
 					</script>
 				</ul>

--- a/tests/scrollableTestApp2/templates/Scrollable4.html
+++ b/tests/scrollableTestApp2/templates/Scrollable4.html
@@ -1,10 +1,10 @@
 <div class="view mblView">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 
-	<div data-dojo-type="dojox.mobile.ScrollableView">
+	<div data-dojo-type="dojox/mobile/ScrollableView">
 
 	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List Four", fixed:"top"'>
-		<span id="sc4back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+		<span id="sc4back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration', url: '#configuration', transitionDir: -1}">Back</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc4insert1x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">1</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc4insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">10</span>
@@ -24,7 +24,6 @@
 					data-mvc-child-type="dojox/mvc/Templated"
 					data-mvc-child-mixins="dojox/mobile/ListItem"
 					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
 							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
 							onClick: function(){setDetailsContext(this.indexAtStartup);}">
 					<script type="dojox/mvc/InlineTemplate">
@@ -34,6 +33,7 @@
 												onClick: function(e){ /*console.log(this); console.log(this.indexAtStartup);console.log(e);*/
 																		removeScrollableItem(this.indexAtStartup); return false; }"
 								style="float: left; color: white; background-color: transparent; background-image: none; border: none;"></div>
+							<div data-dojo-type="dojox/mvc/Output" data-dojo-props="value: at('rel:', 'First')"></div>	
 						</li>
 					</script>
 				</ul>

--- a/tests/scrollableTestApp2/templates/Scrollable5.html
+++ b/tests/scrollableTestApp2/templates/Scrollable5.html
@@ -1,10 +1,10 @@
 <div class="view mblView">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 
-	<div data-dojo-type="dojox.mobile.ScrollableView">
+	<div data-dojo-type="dojox/mobile/ScrollableView">
 
 	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Scrollable List Five", fixed:"top"'>
-		<span id="sc5back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left" 
+		<span id="sc5back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left" 
 		data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration', url: '#configuration', transitionDir: -1}">Back</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc5insert1x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">1</span>
 		<span data-dojo-type="dojox/mobile/ToolBarButton" id="sc5insert10x" data-dojo-props='icon:"mblDomButtonWhitePlus"' style="float:right;">10</span>
@@ -24,7 +24,6 @@
 					data-mvc-child-type="dojox/mvc/Templated"
 					data-mvc-child-mixins="dojox/mobile/ListItem"
 					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
 							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
 							onClick: function(){setDetailsContext(this.indexAtStartup);}">
 					<script type="dojox/mvc/InlineTemplate">
@@ -34,6 +33,7 @@
 												onClick: function(e){ /*console.log(this); console.log(this.indexAtStartup);console.log(e);*/
 																removeScrollableItem(this.indexAtStartup); return false; }"
 								style="float: left; color: white; background-color: transparent; background-image: none; border: none;"></div>
+							<div data-dojo-type="dojox/mvc/Output" data-dojo-props="value: at('rel:', 'First')"></div>	
 						</li>
 					</script>
 				</ul>

--- a/tests/scrollableTestApp2/templates/TestInfo.html
+++ b/tests/scrollableTestApp2/templates/TestInfo.html
@@ -2,11 +2,11 @@
 
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
 
-	<div data-dojo-type="dojox.mobile.ScrollableView">
+	<div data-dojo-type="dojox/mobile/ScrollableView">
 
 		<h1 id="tst1WrapperA" style="visibility:hidden"
 			data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Test Info for Scrollable tests.", fixed:"top"'>
-			<span id="ti1back1" data-dojo-type="dojox.mobile.ToolBarButton" arrow="left"
+			<span id="ti1back1" data-dojo-type="dojox/mobile/ToolBarButton" arrow="left"
 				data-dojo-props="transitionOptions: {title: 'Configure', target: 'configuration', url: '#configuration', transitionDir: -1}">Back</span>
 		</h1>
 
@@ -20,7 +20,7 @@
 			<br><br>
 			<div class="field-title">Note that the tests which use <b>dojox/app/widgets/Container with scrollable:true</b> should use use headers or footers with data-app-constraint="top" or data-app-constraint="bottom" and they should not use headers and footers with fixed:'top' and fixed:'bottom'.</div>
 			<br>
-			<div class="field-title">Note that the tests which use <b>dojox.mobile.ScrollableView</b> should use headers and footers with fixed:'top' and fixed:'bottom' and they should not use headers or footers with data-app-constraint="top" or data-app-constraint="bottom".</div>
+			<div class="field-title">Note that the tests which use <b>dojox/mobile/ScrollableView</b> should use headers and footers with fixed:'top' and fixed:'bottom' and they should not use headers or footers with data-app-constraint="top" or data-app-constraint="bottom".</div>
 			<br>
 			<div class="field-title"><b>Problems with Scrollable List 4 and 5, and the Dojox Mobile Test:</b></div>
 			<div class="field-title">On a phone or tablet also have problems after an  couple of orientation changes, it gets to where you can not scroll to the last items, and after an orientation change from landscape to portrait mode the window size is too small.</div>

--- a/tests/scrollableTestApp2/templates/configuration/ScrollableListSelection.html
+++ b/tests/scrollableTestApp2/templates/configuration/ScrollableListSelection.html
@@ -53,7 +53,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable4', url: '#Scrollable4'}">
 					<div class="textBox">
 						<div class="subject">Scrollable list Four</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
+					Uses dojox/mobile/ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"
@@ -61,7 +61,7 @@
 					transitionOptions: {title:'List',target: 'Scrollable5', url: '#Scrollable5'}">
 					<div class="textBox">
 					<div class="subject">Scrollable list Five</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
+					Uses dojox/mobile/ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
 					</div>				
 				</li>
 				<li data-dojo-type="dojox/mobile/ListItem"

--- a/tests/scrollableTestApp2/templates/repeatDetails.html
+++ b/tests/scrollableTestApp2/templates/repeatDetails.html
@@ -1,6 +1,6 @@
 <div class="view mblView">
 	<script type="dojo/require">at: "dojox/mvc/at"</script>
-	<h1 data-dojo-type="dojox.mobile.Heading" back="Back">Repeat Details</h1>
+	<h1 data-dojo-type="dojox/mobile/Heading" back="Back">Repeat Details</h1>
 	<form name="repeatTestForm" id="repeatTestForm">    
 		<div data-dojo-type="dojox/mvc/Group" 
 			data-dojo-props="target: at(this.loadedModels.repeatmodels, 'cursor')">
@@ -14,14 +14,14 @@
 						<tr>
 							<td style="width: 100px;" class="layout">First Name</td>
 							<td class="layout">							
-								<input  id="firstInput" data-dojo-type="dojox.mobile.TextBox" 
+								<input  id="firstInput" data-dojo-type="dojox/mobile/TextBox" 
 									data-dojo-props="value: at('rel:', 'First'), placeholder:'First Name'">
 							</td>
 						</tr>
 						<tr>
 							<td style="width: 100px;" class="layout">Last Name</td>
 							<td class="layout">
-								<input id="lastInput" data-dojo-type="dojox.mobile.TextBox"
+								<input id="lastInput" data-dojo-type="dojox/mobile/TextBox"
 									 
 									data-dojo-props="placeholder:'Last Name', value: at('rel:', 'Last')">
 							</td>
@@ -29,14 +29,14 @@
 						<tr>
 							<td style="width: 100px;" class="layout">Email</td>
 							<td class="layout">
-								<input  id="emailInput2" data-dojo-type="dojox.mobile.TextBox"
+								<input  id="emailInput2" data-dojo-type="dojox/mobile/TextBox"
 									data-dojo-props="value: at('rel:', 'Email'), placeholder:'Email'">
 							</td>
 						</tr>
 						<tr>
 							<td style="width: 100px;" class="layout">Telephone</td>
 							<td class="layout">
-								<input  id="telInput" data-dojo-type="dojox.mobile.TextBox"
+								<input  id="telInput" data-dojo-type="dojox/mobile/TextBox"
 									data-dojo-props="value: at('rel:', 'Tel'), placeholder:'Telephone'">
 							</td>
 						</tr>

--- a/tests/scrollableTestApp2/templates/tablet/ViewScrollableLists.html
+++ b/tests/scrollableTestApp2/templates/tablet/ViewScrollableLists.html
@@ -52,7 +52,7 @@
 				transitionOptions: {title:'List',target: 'Scrollable4', url: '#Scrollable4'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list Four</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
+					Uses dojox/mobile/ScrollableView (removed height="auto") with a fixed Header and a fixed Footer (transition event fade)					
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"
@@ -60,7 +60,7 @@
 				transitionOptions: {title:'List',target: 'Scrollable5', url: '#Scrollable5'}">
 				<div class="textBox">
 					<div class="subject">Scrollable list Five</div>
-					Uses dojox.mobile.ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
+					Uses dojox/mobile/ScrollableView (removed height="auto") with a fixed Header and No Footer (transition event flip)				
 				</div>				
 			</li>
 			<li data-dojo-type="dojox/mobile/ListItem"

--- a/tests/scrollableTestApp2/views/ListItem-domButtons.js
+++ b/tests/scrollableTestApp2/views/ListItem-domButtons.js
@@ -12,9 +12,6 @@ function(dom, domStyle, connect, registry, at, TransitionEvent, Repeat, getState
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId("mli1back") && this.app.isTablet){ 
 				domStyle.set(dom.byId("mli1back"), "visibility", "hidden"); // hide the back button in tablet mode
 			}

--- a/tests/scrollableTestApp2/views/ListItem-domButtons2.js
+++ b/tests/scrollableTestApp2/views/ListItem-domButtons2.js
@@ -84,9 +84,6 @@ function(dom, domStyle, connect, registry, at, TransitionEvent, Repeat, getState
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId("back3r") && this.app.isTablet){ 
 				domStyle.set(dom.byId("back3r"), "visibility", "hidden"); // hide the back button in tablet mode
 			}

--- a/tests/scrollableTestApp2/views/Scrollable1.js
+++ b/tests/scrollableTestApp2/views/Scrollable1.js
@@ -115,9 +115,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -137,7 +134,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp2/views/Scrollable1P.js
+++ b/tests/scrollableTestApp2/views/Scrollable1P.js
@@ -82,18 +82,6 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 		// datamodel: dojox/mvc/EditStoreRefListController
 		//		The EditStoreRefListController whose model holds the items for the selected list.
 		//
-	/*
-	 					data-dojo-type="dojox/mobile/RoundRectList"
-					data-dojo-mixins="dojox/mvc/WidgetList,dojox/mvc/_InlineTemplateMixin"
-					data-dojo-props="children: this.loadedModels.repeatmodels.model"
-					data-mvc-child-type="dojox/mvc/Templated"
-					data-mvc-child-mixins="dojox/mobile/ListItem"
-					data-mvc-child-props="clickable: true,
-							label: at(this.target, 'First'),
-							transitionOptions: {title:'Details',target:'repeatDetails',url:'#repeatDetails',params:{'cursor':this.indexAtStartup}},
-							onClick: function(){setDetailsContext(this.indexAtStartup);}">					
- 
-	 */	
 		if(!roundRectWidList){
 			var clz = declare([WidgetList, RoundRectList], {});
 			roundRectWidList = new clz({
@@ -111,8 +99,6 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 				},
 				templateString: RoundRectWidListTemplate
 			});
-			//roundRectWidList.placeAt(dom.byId("list_container"));
-			//roundRectWidList.placeAt(dom.byId("list_type").parentNode);
 			roundRectWidList.placeAt(dom.byId("addWidgetHere"));
 			roundRectWidList.startup();
 		}else{
@@ -121,7 +107,6 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 	};
 
 	return {
-		// repeate view init
 		init: function(){
 			app = this.app;
 
@@ -169,9 +154,6 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -193,7 +175,6 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp2/views/Scrollable2.js
+++ b/tests/scrollableTestApp2/views/Scrollable2.js
@@ -111,9 +111,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -124,7 +121,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp2/views/Scrollable3.js
+++ b/tests/scrollableTestApp2/views/Scrollable3.js
@@ -111,9 +111,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -124,7 +121,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp2/views/Scrollable4.js
+++ b/tests/scrollableTestApp2/views/Scrollable4.js
@@ -111,9 +111,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -124,7 +121,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp2/views/Scrollable5.js
+++ b/tests/scrollableTestApp2/views/Scrollable5.js
@@ -111,9 +111,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -124,7 +121,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/scrollableTestApp2/views/TestInfo.js
+++ b/tests/scrollableTestApp2/views/TestInfo.js
@@ -19,9 +19,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		beforeActivate: function(){
 			// summary:
 			//		view life cycle beforeActivate()
-			// description:
-			//		beforeActivate will call refreshData to create the
-			//		model/controller and show the list.
 			if(dom.byId(backId) && this.app.isTablet){ 
 				domStyle.set(dom.byId(backId), "visibility", "hidden"); // hide the back button in tablet mode
 			}
@@ -39,7 +36,6 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 		},
 		
 		
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/simpleModelApp/views/repeat.js
+++ b/tests/simpleModelApp/views/repeat.js
@@ -65,7 +65,6 @@ function(dom, connect, registry, at, Repeat, getStateful, Output){
 			});
 			_connectResults.push(connectResult);
 		},
-		// repeate view destroy
 		destroy: function(){
 			var connectResult = _connectResults.pop();
 			while(connectResult){

--- a/tests/swapViewTestApp/build.profile.js
+++ b/tests/swapViewTestApp/build.profile.js
@@ -1,0 +1,32 @@
+require(["dojox/app/build/buildControlApp"], function(bc){
+});
+
+var profile = {
+	basePath: "..",
+	releaseDir: "./layoutApp/release",
+	action: "release",
+	cssOptimize: "comments",
+/*	multipleAppConfigLayers: true,*/
+	packages:[{
+		name: "dojo",
+		location: "../../../dojo"
+	},{
+		name: "dijit",
+		location: "../../../dijit"
+	},{
+		name: "layoutApp",
+		location: "../../../dojox/app/tests/layoutApp",
+		destLocation: "./dojox/app/tests/layoutApp"
+	},{
+		name: "dojox",
+		location: "../../../dojox"
+	}],
+	layers: {
+		"layoutApp/layoutApp": {
+			include: [ "layoutApp/index.html" ]
+		}
+	}
+};
+
+
+

--- a/tests/swapViewTestApp/config.json
+++ b/tests/swapViewTestApp/config.json
@@ -1,0 +1,137 @@
+{
+	"id": "swapViewTestApp",
+	"name": "Layout By Div Id App",
+	"description": "A Layout test App using a custom layout controller which uses div ids for the layout.",
+	"splash": "splash",
+
+	"loaderConfig": {
+		"paths": {
+			"swapViewTestApp": "../dojox/app/tests/swapViewTestApp"
+		}
+	},
+
+	"dependencies": [
+		"dojox/app/utils/mvcModel",
+		"dojox/mobile/_base",
+		
+		"dojox/mobile/FixedSplitter",
+		"dojox/mobile/Pane",
+		"dojox/mobile/Container",
+		"dojox/mobile/SwapView",
+		"dojox/mobile/PageIndicator",		
+		
+		"dojox/mobile/compat",
+		"dojox/mobile/TabBar",
+		"dojox/mobile/RoundRect",
+		"dojox/mobile/TabBarButton",
+		"dojox/mobile/Button",
+		"dojox/mobile/RoundRect",
+		"dojox/mobile/Heading",
+		"dojox/mobile/ScrollableView",
+		"dojo/store/Memory",
+		"dojox/mvc/EditStoreRefListController",
+		"dojox/mvc/Group",
+        "dojox/mvc/Repeat",
+        "dojox/mvc/Output",
+		"dojox/mobile/View",
+		"dojox/app/widgets/Container"
+	],
+
+	"modules": [],
+	
+	"controllers": [
+		"dojox/app/controllers/History",
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/tests/swapViewTestApp/controllers/DivIdBasedLayout"
+	],
+
+	//stores we are using
+	"stores": {
+	   "namesStore":{
+	       "type": "dojo/store/Memory",
+		   "params": {
+		      "data": "modelApp.names"
+		   }
+	   },
+       "repeatStore":{
+           "type": "dojo/store/Memory",
+           "params": {
+                "data": "modelApp.repeatData"
+           }
+       }
+	},
+
+	//models and instantiation parameters for the models. Including 'type' as a property allows
+	//one to overide the class that will be used for the model.  By default it is dojox/mvc/model
+	"models": {
+	   "names": {
+			"modelLoader": "dojox/app/utils/mvcModel",
+			"type": "dojox/mvc/EditStoreRefListController",
+			"params":{
+				"store": {"$ref":"#stores.namesStore"}
+			}	       
+	   },
+		"repeatmodels": {
+			"modelLoader": "dojox/app/utils/mvcModel",
+			"type": "dojox/mvc/EditStoreRefListController",
+			"params":{
+				"store": {"$ref":"#stores.repeatStore"}
+			}           
+		}
+	}, 
+
+
+	//the name of the view to load when the app is initialized.
+	//"defaultView": "header+navigation+TestInfo",
+	"defaultView": "main+header+navigation+TestInfo+simple+repeatList",
+	
+
+	// these are the possilbe defaultTransitions
+	"defaultTransition": "slide",
+	//"defaultTransition": "none",
+	//"defaultTransition": "fade",
+	//"defaultTransition": "flip",     
+
+	"views": {
+		"main": {
+			"definition" : "swapViewTestApp/views/main.js",
+			"constraint" : "center",
+			"template": "swapViewTestApp/templates/main.html"
+		},	
+		"navigation":{
+			"definition" : "swapViewTestApp/views/navigation.js",
+			"constraint" : "nav1Id",
+			"template": "swapViewTestApp/templates/navigation.html"
+		},
+		"TestInfo": {
+			"definition" : "swapViewTestApp/views/TestInfo.js",
+			"constraint" : "swapView1Id",
+			"template": "swapViewTestApp/templates/TestInfo.html"
+		},	
+		"header":{
+			"definition" : "none",
+			"constraint" : "heading1Id",
+			"template": "swapViewTestApp/templates/header.html"
+		},
+		"simple":{
+			"definition" : "swapViewTestApp/views/simple.js",
+			"constraint" : "swapView2Id",
+			"template": "swapViewTestApp/templates/simple.html",
+			"dependencies":["dojox/mobile/TextBox"]
+		},
+
+		"repeatList":{
+			"definition" : "swapViewTestApp/views/repeat.js",
+			"constraint" : "swapView3Id",
+			"template": "swapViewTestApp/templates/repeat.html",
+			"dependencies":["dojox/mobile/TextBox"]
+		},
+		"repeatDetails":{
+			"definition" : "swapViewTestApp/views/repeatDetails.js",
+			"constraint" : "swapView3Id",
+			"template": "swapViewTestApp/templates/repeatDetails.html",
+			"dependencies":["dojox/mobile/TextBox"]
+		}
+	}	
+}

--- a/tests/swapViewTestApp/controllers/DivIdBasedLayout.js
+++ b/tests/swapViewTestApp/controllers/DivIdBasedLayout.js
@@ -1,0 +1,70 @@
+define(["dojo/_base/declare", "dojo/dom", "dojo/dom-style",
+		"dojo/dom-class", "dojo/dom-attr", "dojo/dom-construct", 
+		"dojox/app/controllers/LayoutBase", "dijit/registry"],
+function(declare, dom, domStyle, domClass, domAttr, domConstruct, LayoutBase, registry){
+	// module:
+	//		dojox/app/tests/swapViewTestApp/controllers/DivIdBasedLayout
+	// summary:
+	//		Will layout an application based upon div ids.  
+	//		Each view will be appended inside the div with the id that matches the value set in the constraints for the view.
+	//		
+
+	return declare("dojox/app/tests/swapViewTestApp/controllers/DivIdBasedLayout", LayoutBase, {
+
+		initLayout: function(event){
+			// summary:
+			//		Response to dojox/app "initLayout" event which is setup in LayoutBase.
+			//		The initLayout event is called once when the View is being created the first time.
+			//
+			// example:
+			//		Use emit to trigger "initLayout" event, and this function will respond to the event. For example:
+			//		|	this.app.emit("initLayout", view);
+			//
+			// event: Object
+			// |		{"view": view, "callback": function(){}};
+			this.app.log("in app/controllers/DivIdBasedLayout.initLayout event.view.name=[",event.view.name,"] event.view.parent.name=[",event.view.parent.name,"]");
+
+
+			this.app.log("in app/controllers/DivIdBasedLayout.initLayout event.view.constraint=",event.view.constraint);
+			var constraint = event.view.constraint;  // constraint holds the region for this view, center, top etc.
+			var parentDiv = dom.byId(constraint);
+			if(parentDiv){  // If the parentDiv is found append this views domNode to it
+				parentDiv.appendChild(event.view.domNode);
+			}else{
+				event.view.parent.domNode.appendChild(event.view.domNode);
+			//	domClass.add(event.view.domNode, constraint);  // set the class to the constraint
+			}
+
+			this.inherited(arguments);
+		},
+
+		onResize: function(){
+			// do nothing on resize
+		},
+
+		hideView: function(view){
+			domStyle.set(view.domNode, "display", "none");
+			//var sc = registry.byId(view.parent.id+"-"+view.constraint);
+			//if(sc){
+			//	sc.removedFromBc = true;
+			//	sc.removeChild(view.domNode);
+			//}
+		},
+
+		showView: function(view){
+			domStyle.set(view.domNode, "display", "");
+			
+			//var sc = registry.byId(view.parent.id+"-"+view.constraint);
+			//if(sc){
+			//	if(sc.removedFromBc){
+			//		sc.removedFromBc = false;
+			//		registry.byId(this.app.id+"-BC").addChild(sc);
+			//		domStyle.set(view.domNode, "display", "");
+			//	}
+			//	domStyle.set(cp.domNode, "display", "");
+			//	sc.selectChild(cp);
+			//	sc.resize();
+			//}
+		}
+	});
+});

--- a/tests/swapViewTestApp/css/layoutApp.css
+++ b/tests/swapViewTestApp/css/layoutApp.css
@@ -1,0 +1,271 @@
+.main {
+	float: left;
+	width: 100%;
+	height: 100% 
+}
+
+.mainCenter {
+	left: 251px !important;
+}
+
+.center {
+	float: left;
+	width: 900px;
+	height: 100% 
+}
+
+/*
+.top {
+	float: top;
+}
+*/
+
+.left {
+	float: left; 
+	width:250px;
+	background-color: #C5CCD3;
+	z-index:100;	
+	height: 100% 
+}
+
+#headerBackButton {
+	display: none;
+}
+
+@media screen and (max-width: 1154px) {
+	.center {
+		float: left;
+		width: 600px 
+	}
+
+	.left {
+		float: left; 
+		width:250px;
+		background-color: #C5CCD3;
+		z-index:100;	
+		height: 100% 
+	}
+
+}
+
+@media screen and (max-width: 854px) {
+	.center {
+		float: left;
+		width: 520px;
+		height: 100%;
+		
+	}
+
+	.left {
+		float: left; 
+		width:250px;
+		background-color: #C5CCD3;
+		z-index:100;	
+		height: 100% 
+	}
+
+}
+
+@media screen and (max-width: 560px) {
+	.center {
+		float: left;
+		width: 100%; 
+	}
+
+	.mainCenter {
+		left: 0px !important;
+	}
+
+	.left {
+		display: none;
+		float: left; 
+		width:0px;
+	}
+
+	#headerBackButton {
+		display: block;
+	}
+
+}
+
+
+@media only screen and (orientation: portrait) {
+	.center {
+		float: left;
+		width: 100%; 
+	}
+
+	.mainCenter {
+		left: 0px !important;
+	}
+
+	.left {
+		display: none;
+		float: left; 
+		width:0px;
+	}
+
+	#headerBackButton {
+		display: block;
+	}
+}
+
+@media only screen and (orientation: landscape) and (max-width: 568px) {
+	.center {
+		float: left;
+		width: 360px;
+		height: 100%;
+	}
+
+	.mainCenter {
+		left: 151px !important;
+	}
+
+	.left {
+		float: left; 
+		width:150px;
+		background-color: #C5CCD3;
+		z-index:100;	
+		height: 100% 
+	}
+
+}
+
+/*@media only screen and (device-width: 480px) and (orientation: landscape) and (resolution: 163dpi) { */
+	/* CSS3 Rules for XX iPhone in Portrait Orientation */
+/*@media only screen and (device-width: 568px) and (orientation: landscape) {
+	.center {
+		float: left;
+		width: 300px;
+		height: 100%;
+		
+	}
+
+	.left {
+		float: left; 
+		width:100px;
+		border-right:1px solid black;
+		background-color: #C5CCD3;
+		z-index:100;	
+		height: 100% 
+	}
+}
+*/
+
+
+
+html,body {
+	width: 100%;
+	height: 100%;
+}
+
+button.baseBtn {
+	-webkit-background-clip: padding-box;
+	-webkit-box-align: center;
+	background-clip: padding-box;
+	border-style: solid;
+	border-width: 1px;
+	color: black;
+	font-family: 'Helvetica Neue', HelveticaNeue, Helvetica-Neue, Helvetica, 'BBAlpha Sans';
+	font-size: 18px;
+	font-weight: bold;
+	vertical-align: middle;
+	margin: 10px;
+	height: 34px;
+	border-bottom-left-radius: 7px;
+	border-bottom-right-radius: 7px;
+	border-top-left-radius: 7px;
+	border-top-right-radius: 7px;
+	width: 240px;
+}
+
+button.whiteBtn{
+	background-image: -webkit-gradient(linear, 0% 0, 0% 100%, from(white), color-stop(0.06, #f2f2f2), to(#b7b7b7));
+	border-color: #979797;
+	border-bottom-color: #727272;
+}
+
+button.whiteBtnSelected{
+	background-image: -webkit-gradient(linear, 0% 0, 0% 100%, from(#ffffff), color-stop(0.06, #bbbbbb), to(#fcfcfc));
+	border-color: #979797;
+	border-bottom-color: #727272;
+}
+
+#header button {
+	position:absolute;
+	margin:0px;
+}
+
+#navButton {
+	width:60px;
+}
+
+#loadDiv {
+	position:absolute;
+	left:0px;
+	top:0px;
+	width:100%;
+	height:100%;
+	z-index:999;
+}
+#loadDiv {
+	display:table;
+	font-size: 20px;
+	text-align:center;
+	background-color:white;
+}
+#loadDiv span {
+	display:table-cell;
+	vertical-align:middle;
+}
+
+body .mblProgContainer {
+	top:45%;
+	height: 45px;
+	width: 140px;
+	margin-left:-70px;
+	background-color: #2A2A28;
+	border-style: solid;
+	border-width: 2px;
+	border-color: #666666;
+	border-radius: 0.4em;
+	-webkit-border-radius: 0.4em;
+	-moz-border-radius: 0.4em;
+}
+
+body .mblProgContainer > div {
+	height: 100%;
+	width: 100%;
+	line-height: 45px;
+	vertical-align: middle;
+	font-size: 20px;
+	color: #c2c2c2;
+}
+
+body .mblProg {
+	left: 3px;
+	top: 3px;
+}
+
+#jsContent, #htmlContent {
+	padding-left:2px;
+}
+
+@media screen and (max-width: 600px) {
+	#jsContent, #htmlContent {
+		font-size: 14px;
+	}
+}
+
+.hidden {
+	display:none;
+}
+
+/*
+.navPane {
+	width:250px;
+	border-right:1px solid black;
+	background-color: #C5CCD3;
+	z-index:100;
+}
+*/

--- a/tests/swapViewTestApp/index.html
+++ b/tests/swapViewTestApp/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+	<head>
+		<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"/>
+		<meta name="apple-mobile-web-app-capable" content="yes" />
+	<meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+
+		<title>Media Query Layout App</title>
+		<link type="text/css" href="./css/layoutApp.css" rel="stylesheet" />
+		<script type="text/javascript" src="../../../../dojox/mobile/deviceTheme.js"></script>
+		<script type="text/javascript" src="../../../../dojo/dojo.js" data-dojo-config="parseOnLoad: false,
+				mblHideAddressBar: false,
+				mblAndroidWorkaround: false,
+				mblAlwaysHideAddressBar: false,
+				app: {debugApp: 1},  // set debugApp to log app transtions and view activate/deactivate
+				async: 1">
+		</script>
+		<script>
+			require(["./layoutApp.js"], function(){
+			});
+		</script>
+
+		
+	</head>
+	<body>
+	</body>
+</html>

--- a/tests/swapViewTestApp/layoutApp.js
+++ b/tests/swapViewTestApp/layoutApp.js
@@ -1,0 +1,58 @@
+require(["dojo/_base/window","dojox/app/main", "dojox/json/ref", "dojo/text!./config.json", "dojo/sniff"],
+	function(win, Application, jsonRef, config, has){
+	win.global.modelApp = {};
+	modelApp.names = {
+		identifier: "id",
+		items: [{
+			"id": "1",
+			"Serial": "360324",
+			"First": "John",
+			"Last": "Doe",
+			"Email": "jdoe@us.ibm.com",
+			"ShipTo": {
+				"Street": "123 Valley Rd",
+				"City": "Katonah",
+				"State": "NY",
+				"Zip": "10536"
+			},
+			"BillTo": {
+				"Street": "17 Skyline Dr",
+				"City": "Hawthorne",
+				"State": "NY",
+				"Zip": "10532"
+			}
+		}]
+	};
+	modelApp.repeatData = [{
+		"First": "Chad",
+		"Last": "Chapman",
+		"Location": "CA",
+		"Office": "1278",
+		"Email": "c.c@test.com",
+		"Tel": "408-764-8237",
+		"Fax": "408-764-8228"
+	}, {
+		"First": "Irene",
+		"Last": "Ira",
+		"Location": "NJ",
+		"Office": "F09",
+		"Email": "i.i@test.com",
+		"Tel": "514-764-6532",
+		"Fax": "514-764-7300"
+	}, {
+		"First": "John",
+		"Last": "Jacklin",
+		"Location": "CA",
+		"Office": "6701",
+		"Email": "j.j@test.com",
+		"Tel": "408-764-1234",
+		"Fax": "408-764-4321"
+	}];
+	var config = jsonRef.fromJson(config);
+	// on IE use the HistoryHash controller instead of the History controller.
+	//console.log("has(ie)="+has("ie"));
+	config.controllers[0] = has("ie") ? "dojox/app/controllers/HistoryHash" : "dojox/app/controllers/History";		
+	//console.log("config.controllers[0]="+config.controllers[0]);
+	Application(config);
+	
+});

--- a/tests/swapViewTestApp/layoutApp.profile.js
+++ b/tests/swapViewTestApp/layoutApp.profile.js
@@ -1,0 +1,13 @@
+var profile = {
+	resourceTags:{
+		declarative: function(filename){
+	 		return /\.html?$/.test(filename); // tags any .html or .htm files as declarative
+	 	},
+		amd: function(filename){
+			return /\.js$/.test(filename);
+		},
+		copyOnly: function(filename, mid){
+			return mid == "layoutApp/build.profile";
+		}
+	}
+};

--- a/tests/swapViewTestApp/package.json
+++ b/tests/swapViewTestApp/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "layoutApp",
+	"dojoBuild": "layoutApp.profile.js"
+}

--- a/tests/swapViewTestApp/templates/TestInfo.html
+++ b/tests/swapViewTestApp/templates/TestInfo.html
@@ -1,0 +1,23 @@
+<div class="view mblView">
+
+	<script type="dojo/require">at: "dojox/mvc/at"</script>
+
+	<!--<div data-dojo-type="dojox/mobile/ScrollableView"> -->
+	<div>
+		<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Test Info for this test.</h2>
+
+		<div>
+			<div class="field-title">This test has been setup to use a custom layout controller (DivIdBasedLayout) along with mobile/SwapView and mobile/PageIndicator.</div>
+			<div class="field-title">The DivIdBasedLayout will try to layout views by appending them inside the div with the id that matches the value set in the constraints for the view.</div>
+			<br>
+			<div class="field-title">There are 3 views shown in the SwapViews, they can be seen by swipping from the left to the right in the main content area, the Header and Nav area are also added to the main area by div id.</div>
+			<div class="field-title">The 3rd view will transition to a details view, which will add a Back button to return to this view, the swapViews are still active after the transition.</div>
+			<br>
+			<div class="field-title">Some of the css from the mediaQueryLayout test is included, so on a desktop you can make the window smaller and the navigation area will become hidden when the screen gets less than max-width: 560px.</div>
+			<div class="field-title">And on a phone or tablet the Naviagtion will be hidden in portrait orientation and shown in landscape orientation.</div>
+			<br>
+			<div class="field-title">Should try to get rid of the FixedSplitters in main.html and just use css for positioning, also add nested footer and right side nav.</div>
+			<br><br>
+		</div>
+	</div>
+</div>

--- a/tests/swapViewTestApp/templates/header.html
+++ b/tests/swapViewTestApp/templates/header.html
@@ -1,0 +1,4 @@
+<div>
+	<!-- top -->
+	<div data-dojo-type="dojox/mobile/Heading"  fixed:"top">This shows a SwapView with a PageIndicator</div>
+</div>

--- a/tests/swapViewTestApp/templates/main.html
+++ b/tests/swapViewTestApp/templates/main.html
@@ -1,0 +1,35 @@
+<div id="settings" class="view mblView main">
+	<script type="dojo/require">at: "dojox/mvc/at"</script>
+	<div data-dojo-type="dojox/mobile/FixedSplitter" data-dojo-props='orientation:"V"'>
+		<div data-dojo-type="dojox/mobile/Container" style="overflow:hidden;">
+		<!--	<div data-dojo-type="dojox/mobile/Heading"  fixed:"top">This is a SwapView with a PageIndicator</div> -->
+			<div id="heading1Id"></div>
+		</div>
+		
+	<div data-dojo-type="dojox/mobile/FixedSplitter" data-dojo-props='orientation:"H"'>
+		<div data-dojo-type="dojox/mobile/Container" style="overflow:hidden;  border-right: 1px solid black;">
+			<div id="nav1Id"></div>
+		</div>
+
+		<div data-dojo-type="dojox/mobile/Container" class="mainCenter" style="overflow:hidden;">
+			<div id="swap1" data-dojo-type="dojox/mobile/SwapView">
+				<div data-dojo-type="dojox/mobile/ScrollableView" data-dojo-props='height:"100%"'>
+					<div id="swapView1Id"></div>
+				</div>
+			</div>
+
+			<div id="swap2" data-dojo-type="dojox/mobile/SwapView">
+				<div data-dojo-type="dojox/mobile/ScrollableView" data-dojo-props='height:"100%"'>
+					<div id="swapView2Id"></div>
+				</div>
+			</div>
+
+			<div id="swap3" data-dojo-type="dojox/mobile/SwapView">
+					<div id="swapView3Id"></div>
+			</div>
+
+			<div data-dojo-type="dojox/mobile/PageIndicator" data-dojo-props='fixed:"bottom"'></div>
+		</div>
+	</div>
+	</div>
+</div>

--- a/tests/swapViewTestApp/templates/navigation.html
+++ b/tests/swapViewTestApp/templates/navigation.html
@@ -1,0 +1,21 @@
+<div class="navPane">
+	<!-- left -->
+	<div data-dojo-type="dojox/app/widgets/Container" id="NavWidId" class="navPane left" data-app-constraint="left">
+
+	<!-- <div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" data-dojo-props="scrollable:true">  -->
+		<div>
+		<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Navigation</h2>
+			<ul data-dojo-type="dojox/mobile/RoundRectList" data-app-constraint="center">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true">
+					Dummy item 1
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true">
+					Dummy item 2
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true">
+					Dummy item 3
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>

--- a/tests/swapViewTestApp/templates/repeat.html
+++ b/tests/swapViewTestApp/templates/repeat.html
@@ -1,0 +1,24 @@
+<div class="view mblView">
+	<script type="dojo/require">at: "dojox/mvc/at"</script>
+   	<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Repeat Data Binding Example</h2>
+ 
+    <form name="repeatTestForm" id="repeatTestForm">    
+    	<div class="field-title">Search Results</div>
+        <div id="repeatWidget" class="fieldset" data-dojo-type="dojox/mvc/Repeat" 
+        	data-dojo-props="exprchar: '#', children: this.loadedModels.repeatmodels.model" >
+           <div class="row">            
+                    <input data-dojo-type="dojox/mobile/TextBox"
+                        id="nameInput#{this.index}" data-dojo-props="value: at('rel:#{this.index}','First')" placeHolder="First Name"></input>
+                    <button type="button" id="detail#{this.index}" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+                        Details
+                    </button>
+                    <button type="button" id="insert#{this.index}" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+                        +
+                    </button>
+                    <button type="button" id="delete#{this.index}" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+                        -
+                    </button>
+			</div>
+        </div>
+	</form>
+</div>

--- a/tests/swapViewTestApp/templates/repeatDetails.html
+++ b/tests/swapViewTestApp/templates/repeatDetails.html
@@ -1,0 +1,48 @@
+<div class="view mblView">
+	<script type="dojo/require">at: "dojox/mvc/at"</script>
+    <h4 data-dojo-type="dojox/mobile/Heading" back="Back">Repeat Details</h4>
+   	<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory"  back="Back" style="height: 32px;" data-app-constraint="top">Repeat Data Binding Example</h2>
+    
+    <form name="repeatTestForm" id="repeatTestForm">    
+		<div data-dojo-type="dojox/mvc/Group" 
+			data-dojo-props="target: at(this.loadedModels.repeatmodels, 'cursor')">
+					<div class="field-title">
+						<div style="display: inline-block;" id="detailsBanner">Details for selected index:</div>
+						<span class="cell" id="indexOutput"
+							data-dojo-type="dojox/mvc/Output"
+							data-dojo-props="value: at(this.loadedModels.repeatmodels, 'cursorIndex')"></span>
+					</div>
+					<table id="table" cellspacing="10"  style="width: 100%">
+						<tr>
+							<td style="width: 100px;" class="layout">First Name</td>
+							<td class="layout">							
+								<input  id="firstInput" data-dojo-type="dojox/mobile/TextBox" 
+									data-dojo-props="value: at('rel:', 'First'), placeholder:'First Name'">
+							</td>
+						</tr>
+						<tr>
+							<td style="width: 100px;" class="layout">Last Name</td>
+							<td class="layout">
+								<input id="lastInput" data-dojo-type="dojox/mobile/TextBox"
+									 
+									data-dojo-props="placeholder:'Last Name', value: at('rel:', 'Last')">
+							</td>
+						</tr>
+						<tr>
+							<td style="width: 100px;" class="layout">Email</td>
+							<td class="layout">
+								<input  id="emailInput2" data-dojo-type="dojox/mobile/TextBox"
+									data-dojo-props="value: at('rel:', 'Email'), placeholder:'Email'">
+							</td>
+						</tr>
+						<tr>
+							<td style="width: 100px;" class="layout">Telephone</td>
+							<td class="layout">
+								<input  id="telInput" data-dojo-type="dojox/mobile/TextBox"
+									data-dojo-props="value: at('rel:', 'Tel'), placeholder:'Telephone'">
+							</td>
+						</tr>
+					</table>
+		</div>
+		</form>
+</div>

--- a/tests/swapViewTestApp/templates/simple.html
+++ b/tests/swapViewTestApp/templates/simple.html
@@ -1,0 +1,90 @@
+<div id="settings" class="view mblView">
+	<script type="dojo/require">at: "dojox/mvc/at"</script>
+	<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" style="height: 32px;" data-app-constraint="top">Simple Data Binding Example</h2>
+	
+		<form name="testForm" id="testForm">
+			<div class="field-title">
+				Ship to - Bill to Address
+			</div>
+			<div class="fieldset" data-dojo-type="dojox/mvc/Group" data-dojo-props="target: at(this.loadedModels.names, 'model')">
+				<div data-dojo-type="dojox/mvc/Group" data-dojo-props="target: at('rel:', 0)">
+					<table id="table" cellspacing="10" style="width: 100%">
+						<tr>
+							<td style="width: 100px;" class="layout">
+								First
+							</td>
+							<td class="layout">
+								<input id="firstInput1" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'First'), placeholder:'First'">
+							</td>
+						</tr>
+						<tr>
+							<td style="width: 100px;" class="layout">
+								Last Name
+							</td>
+							<td class="layout">
+								<input id="lastInput1" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="placeholder:'Last Name', value: at('rel:', 'Last')">
+							</td>
+						</tr>
+						<tr>
+							<td style="width: 100px;" class="layout">
+								Email
+							</td>
+							<td class="layout">
+								<input id="emailInput1" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'Email'), placeholder:'Email'">
+							</td>
+						</tr>
+					</table>
+					<div class="spacer">
+					</div>
+					<button id="shipto" type="button" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+						Ship To
+					</button>
+					<button id="billto" type="button" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+						Bill To
+					</button>
+					<br/>
+					<div class="fieldset" id="addrGroup" data-dojo-type="dojox/mvc/Group" data-dojo-props="target: at('rel:','ShipTo')">
+						<table id="table" cellspacing="10" style="width: 100%">
+							<tr>
+								<td style="width: 100px;" class="layout">
+									Street
+								</td>
+								<td class="layout">
+									<input id="streetInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'Street'), placeholder:'Street'">
+								</td>
+							</tr>
+							<tr>
+								<td style="width: 100px;" class="layout">
+									City
+								</td>
+								<td class="layout">
+									<input id="cityInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="placeholder:'City', value: at('rel:', 'City')">
+								</td>
+							</tr>
+							<tr>
+								<td style="width: 100px;" class="layout">
+									State
+								</td>
+								<td class="layout">
+									<input id="StateInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'State'), placeholder:'State'">
+								</td>
+							</tr>
+							<tr>
+								<td style="width: 100px;" class="layout">
+									State
+								</td>
+								<td class="layout">
+									<input id="ZipInput" data-dojo-type="dojox/mobile/TextBox" data-dojo-props="value: at('rel:', 'Zip'), placeholder:'Zip Code'">
+								</td>
+							</tr>
+						</table>
+					</div>
+				</div>
+			</div>
+			<div class="spacer">
+			</div>
+			<button id="reset1" type="button" data-dojo-type="dojox/mobile/Button" class="mblBlueButton">
+				Reset
+			</button>
+		</form>
+</div>

--- a/tests/swapViewTestApp/views/TestInfo.js
+++ b/tests/swapViewTestApp/views/TestInfo.js
@@ -1,0 +1,58 @@
+define(["dojo/dom", "dojo/dom-style", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mobile/TransitionEvent", 
+	"dojo/Stateful", "dojox/mvc/parserExtension", "dojox/mvc/sync"],
+function(dom, domStyle, connect, registry, at, TransitionEvent, Stateful, parserExtension, sync){
+	var _connectResults = []; // events connect result
+	var previousView = null;
+
+	navShowingStateful = new Stateful({value: false});
+
+	return {
+		// view init
+		init: function(){
+		},
+		
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			currentModel = this.loadedModels.names;
+			var connectResult;
+		/*	
+			var backButtomDom = dom.byId('headerBackButton');
+			connectResult = connect.connect(backButtomDom, "onclick", function(e){
+				// transition to repeatDetails view with the &cursor=index
+				
+				var transOpts = {
+					title:'main+TestInfo+simple+repeatList+navigation+header',
+					target:'main+TestInfo+simple+repeatList+navigation+header',
+					url:'#main+TestInfo+simple+repeatList+navigation+header'					
+				};
+				new TransitionEvent(e.target, transOpts, e).dispatch(); 
+
+			});
+		*/	
+			
+		},
+
+
+		afterDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		},
+		
+		// repeat view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/swapViewTestApp/views/main.js
+++ b/tests/swapViewTestApp/views/main.js
@@ -1,0 +1,76 @@
+define(["dojo/dom", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mobile/TransitionEvent"],
+function(dom, connect, registry, at,TransitionEvent){
+	var _connectResults = []; // events connect results
+	var currentModel = null;
+
+	var setRef = function (id, attr){
+		var widget = registry.byId(id);
+		widget.set("target", at("rel:", attr));
+		console.log("setRef done.");
+	};
+	return {
+		// main view init
+		init: function(){
+		},
+		
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			currentModel = this.loadedModels.names;
+			var connectResult;
+
+			connectResult = connect.connect(dom.byId('shipto'), "click", function(){
+				setRef('addrGroup', 'ShipTo');
+			});
+			_connectResults.push(connectResult);
+
+			connectResult = connect.connect(dom.byId('billto'), "click", function(){
+				setRef('addrGroup', 'BillTo');
+			});
+			_connectResults.push(connectResult);
+
+			connectResult = connect.connect(dom.byId('reset1'), "click", function(){
+				currentModel.reset();
+				console.log("reset done. ");
+			});
+			_connectResults.push(connectResult);
+		/*	
+			var backButtomDom = dom.byId('headerBackButton');
+			connectResult = connect.connect(backButtomDom, "onclick", function(e){
+				// transition to repeatDetails view with the &cursor=index
+				
+				var transOpts = {
+					title:'main+TestInfo+simple+repeatList+navigation+header',
+					target:'main+TestInfo+simple+repeatList+navigation+header',
+					url:'#main+TestInfo+simple+repeatList+navigation+header'					
+				};
+				new TransitionEvent(e.target, transOpts, e).dispatch(); 
+
+			});
+		*/	
+			
+		},
+
+		afterDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		},
+		
+
+		// main view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/swapViewTestApp/views/navigation.js
+++ b/tests/swapViewTestApp/views/navigation.js
@@ -1,0 +1,39 @@
+define(["dojo/dom", "dojo/dom-style", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mobile/TransitionEvent", 
+	"dojo/Stateful", "dojox/mvc/parserExtension", "dojox/mvc/sync"],
+function(dom, domStyle, connect, registry, at, TransitionEvent, Stateful, parserExtension, sync){
+	var _connectResults = []; // events connect result
+	var previousView = null;
+
+	navShowingStateful = new Stateful({value: false});
+
+	return {
+		// view init
+		init: function(){
+		},
+		
+		beforeActivate: function(view, data){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			this.previousView = view;
+			
+			// setup code to watch for the navigation pane being visible
+			
+		},
+
+		beforeDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+		},
+		
+		// repeat view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/swapViewTestApp/views/repeat.js
+++ b/tests/swapViewTestApp/views/repeat.js
@@ -1,0 +1,119 @@
+define(["dojo/dom", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mobile/TransitionEvent", "dojox/mvc/Repeat", "dojox/mvc/getStateful", "dojox/mvc/Output"],
+function(dom, connect, registry, at, TransitionEvent, Repeat, getStateful, Output){
+	var _connectResults = []; // events connect result
+
+	var repeatmodel = null;	//repeat view data model
+
+	// delete an item
+	var deleteResult = function(index){
+		var nextIndex = repeatmodel.get("cursorIndex");
+		if(nextIndex >= index){
+			nextIndex = nextIndex-1;
+		}
+		repeatmodel.model.splice(index, 1);
+		repeatmodel.set("cursorIndex", nextIndex);		
+	};
+	// show an item detail
+	var setDetailsContext = function(index,e){
+		repeatmodel.set("cursorIndex", index);
+
+		// transition to repeatDetails view with the &cursor=index
+		var transOpts = {
+			title : "main+TestInfo+simple+repeatDetails+navigation+header",
+			target : "main+TestInfo+simple+repeatDetails+navigation+header",
+			url : "#main+TestInfo+simple+repeatDetails+navigation+header", // this is optional if not set it will be created from target   
+			params : {"cursor":index}
+		};
+		new TransitionEvent(e.target, transOpts, e).dispatch(); 
+		
+	};
+	// insert an item
+	var insertResult = function(index, e){
+		if(index<0 || index>repeatmodel.model.length){
+			throw Error("index out of data model.");
+		}
+		if((repeatmodel.model[index].First=="") ||
+			(repeatmodel.model[index+1] && (repeatmodel.model[index+1].First == ""))){
+			return;
+		}
+		var data = {id:Math.random(), "First": "", "Last": "", "Location": "CA", "Office": "", "Email": "", "Tel": "", "Fax": ""};
+		repeatmodel.model.splice(index+1, 0, new getStateful(data));
+		setDetailsContext(index+1, e);
+	};
+	// get index from dom node id
+	var getIndexFromId = function(nodeId, perfix){
+		var len = perfix.length;
+		if(nodeId.length <= len){
+			throw Error("repeate node id error.");
+		}
+		var index = nodeId.substring(len, nodeId.length);
+		return parseInt(index);
+	};
+
+	return {
+		// repeate view init
+		init: function(){
+			repeatmodel = this.loadedModels.repeatmodels;
+		},
+		
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var repeatDom = dom.byId('repeatWidget');
+			var connectResult;
+			connectResult = connect.connect(repeatDom, "button[id^=\"detail\"]:click", function(e){
+				var index = getIndexFromId(e.target.id, "detail");
+				setDetailsContext(index, e);
+			});
+			_connectResults.push(connectResult);
+
+			connectResult = connect.connect(repeatDom, "button[id^=\"insert\"]:click", function(e){
+				var index = getIndexFromId(e.target.id, "insert");
+				insertResult(index, e);
+			});
+			_connectResults.push(connectResult);
+
+			connectResult = connect.connect(repeatDom, "button[id^=\"delete\"]:click", function(e){
+				var index = getIndexFromId(e.target.id, "delete");
+				deleteResult(index);
+			});
+			_connectResults.push(connectResult);
+		/*	
+			var backButtomDom = dom.byId('headerBackButton');
+			connectResult = connect.connect(backButtomDom, "onclick", function(e){
+				// transition to repeatDetails view with the &cursor=index
+				
+				var transOpts = {
+					title:'main+TestInfo+simple+repeatList+navigation+header',
+					target:'main+TestInfo+simple+repeatList+navigation+header',
+					url:'#main+TestInfo+simple+repeatList+navigation+header'					
+				};
+				new TransitionEvent(e.target, transOpts, e).dispatch(); 
+
+			});
+		*/	
+			
+		},
+
+		afterDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		},
+		
+		// repeat view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/swapViewTestApp/views/repeatDetails.js
+++ b/tests/swapViewTestApp/views/repeatDetails.js
@@ -1,0 +1,41 @@
+define(["dojo/dom", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mvc/getStateful", "dojox/mvc/Output"],
+function(dom, connect, registry, at, getStateful, Output){
+	var _connectResults = []; // events connect result
+
+	var repeatmodel = null;	//repeat view data model
+
+	// show an item detail
+	var setDetailsContext = function(index){
+		// only set the cursor if it is different and valid
+		if(parseInt(index) != repeatmodel.cursorIndex && parseInt(index) < repeatmodel.model.length){
+			repeatmodel.set("cursorIndex", parseInt(index));
+		}
+	};
+
+	// get index from dom node id
+	var getIndexFromId = function(nodeId, perfix){
+		var len = perfix.length;
+		if(nodeId.length <= len){
+			throw Error("repeate node id error.");
+		}
+		var index = nodeId.substring(len, nodeId.length);
+		return parseInt(index);
+	};
+
+	return {
+		// repeate view init
+		init: function(){
+			repeatmodel = this.loadedModels.repeatmodels;
+		},
+
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			// if this.params["cursor"] is set use it to set the selected Details Context
+			if(this.params["cursor"]){
+				setDetailsContext(this.params["cursor"]);
+			}
+		}
+	}
+});

--- a/tests/swapViewTestApp/views/simple.js
+++ b/tests/swapViewTestApp/views/simple.js
@@ -1,0 +1,76 @@
+define(["dojo/dom", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mobile/TransitionEvent"],
+function(dom, connect, registry, at,TransitionEvent){
+	var _connectResults = []; // events connect results
+	var currentModel = null;
+
+	var setRef = function (id, attr){
+		var widget = registry.byId(id);
+		widget.set("target", at("rel:", attr));
+		console.log("setRef done.");
+	};
+	return {
+		// simple view init
+		init: function(){
+		},
+		
+		beforeActivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			currentModel = this.loadedModels.names;
+			var connectResult;
+
+			connectResult = connect.connect(dom.byId('shipto'), "click", function(){
+				setRef('addrGroup', 'ShipTo');
+			});
+			_connectResults.push(connectResult);
+
+			connectResult = connect.connect(dom.byId('billto'), "click", function(){
+				setRef('addrGroup', 'BillTo');
+			});
+			_connectResults.push(connectResult);
+
+			connectResult = connect.connect(dom.byId('reset1'), "click", function(){
+				currentModel.reset();
+				console.log("reset done. ");
+			});
+			_connectResults.push(connectResult);
+		/*	
+			var backButtomDom = dom.byId('headerBackButton');
+			connectResult = connect.connect(backButtomDom, "onclick", function(e){
+				// transition to repeatDetails view with the &cursor=index
+				
+				var transOpts = {
+					title:'main+TestInfo+simple+repeatList+navigation+header',
+					target:'main+TestInfo+simple+repeatList+navigation+header',
+					url:'#main+TestInfo+simple+repeatList+navigation+header'					
+				};
+				new TransitionEvent(e.target, transOpts, e).dispatch(); 
+
+			});
+		*/	
+			
+		},
+
+		afterDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		},
+		
+
+		// simple view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/widgets/Container.js
+++ b/widgets/Container.js
@@ -77,6 +77,10 @@ function(declare, lang, registry, domAttr, domGeom, domStyle, WidgetBase, Contai
 
 			var node = this.domNode;
 
+			if(this.scrollable){
+				this.inherited(arguments);
+			}
+
 			// set margin box size, unless it wasn't specified, in which case use current size
 			if(changeSize){
 				domGeom.setMarginBox(node, changeSize);

--- a/widgets/_ScrollableMixin.js
+++ b/widgets/_ScrollableMixin.js
@@ -2,16 +2,18 @@
 define([
 	"dojo/_base/declare",
 	"dojo/_base/lang",
+	"dojo/_base/array",
 	"dojo/dom-class",
 	"dojo/dom-construct",
 	"dojox/mobile/scrollable"],
-	function(declare, lang, domClass, domConstruct, Scrollable){
+	function(declare, lang, array, domClass, domConstruct, Scrollable){
 	// module:
 	//		dojox/mobile/_ScrollableMixin
 	// summary:
 	//		Mixin for widgets to have a touch scrolling capability.
 
-	var cls = declare("dojox.app.widgets._ScrollableMixin", null, {
+//	var cls = declare("dojox.app.widgets._ScrollableMixin", null, {
+	var cls = declare("dojox.app.widgets._ScrollableMixin", Scrollable, {
 		// summary:
 		//		Mixin for widgets to have a touch scrolling capability.
 		// description:
@@ -84,6 +86,6 @@ define([
 			});
 		}
 	});
-	lang.extend(cls, new Scrollable());
+	//lang.extend(cls, new Scrollable());
 	return cls;
 });


### PR DESCRIPTION
In transition controller I removed the check for IE around the call to css3 transit, since transit is now checking it, and we may want to call it for a custom transit for ie, also in transition controller I fixed problem where a view was being removed from a constraint even if it was not the selectedChild for that constraint, for example if view7 were shown in the right constraint and a transition was done for -view8, view7 was being removed, but it should have stayed.  In main I added support for a config option (observable: true) to indicate that the store should be wrapped in a dojo/store/Observable.  There was another problem with an EdgeToEdgeStoreList with a LongListMixin in a scrollable Container,  app/widgets/Container and app/widgets/_ScrollableMixin were updated to have _ScrollableMixin actually extend mobile/Scrollable and have Container call this.inherited(arguments); for resize to fix it.  Also many of the tests were cleaned up and 3 new tests were added.
