### PR TITLE
Change the app events being used in our controllers to be prefixed with app-, so for example in ViewBase "initLayout", "layoutView" and "resize" will become "app-initLayout", "app-layoutView" and "app-resize".

### DIFF
--- a/ViewBase.js
+++ b/ViewBase.js
@@ -108,7 +108,7 @@ define(["require", "dojo/when", "dojo/on", "dojo/dom-attr", "dojo/_base/declare"
 			constraints.register(this.constraint);
 
 
-			this.app.emit("initLayout", {
+			this.app.emit("app-initLayout", {
 				"view": this, 
 				"callback": lang.hitch(this, function(){
 						//start widget

--- a/controllers/BorderLayout.js
+++ b/controllers/BorderLayout.js
@@ -12,12 +12,12 @@ function(declare, domAttr, domStyle, LayoutBase, BorderContainer, StackContainer
 
 		initLayout: function(event){
 			// summary:
-			//		Response to dojox/app "initLayout" event which is setup in LayoutBase.
+			//		Response to dojox/app "app-initLayout" event which is setup in LayoutBase.
 			//		The initLayout event is called once when the View is being created the first time.
 			//
 			// example:
-			//		Use emit to trigger "initLayout" event, and this function will respond to the event. For example:
-			//		|	this.app.emit("initLayout", view);
+			//		Use emit to trigger "app-initLayout" event, and this function will respond to the event. For example:
+			//		|	this.app.emit("app-initLayout", view);
 			//
 			// event: Object
 			// |		{"view": view, "callback": function(){}};

--- a/controllers/History.js
+++ b/controllers/History.js
@@ -3,7 +3,7 @@ function(lang, declare, on, Controller, hash){
 	// module:
 	//		dojox/app/controllers/History
 	// summary:
-	//		Bind "domNode" event on dojox/app application instance,
+	//		Bind "app-domNode" event on dojox/app application instance,
 	//		Bind "startTransition" event on dojox/app application domNode,
 	//		Bind "popstate" event on window object.
 	//		Maintain history by HTML5 "pushState" method and "popstate" event.
@@ -11,7 +11,7 @@ function(lang, declare, on, Controller, hash){
 	return declare("dojox.app.controllers.History", Controller, {
 		constructor: function(app){
 			// summary:
-			//		Bind "domNode" event on dojox/app application instance,
+			//		Bind "app-domNode" event on dojox/app application instance,
 			//		Bind "startTransition" event on dojox/app application domNode,
 			//		Bind "popstate" event on window object.
 			//
@@ -19,7 +19,7 @@ function(lang, declare, on, Controller, hash){
 			//		dojox/app application instance.
 
 			this.events = {
-				"domNode": this.onDomNodeChange
+				"app-domNode": this.onDomNodeChange
 			};
 			if(this.app.domNode){
 				this.onDomNodeChange({oldNode: null, newNode: this.app.domNode});
@@ -103,7 +103,7 @@ function(lang, declare, on, Controller, hash){
 			}
 
 			// transition to the target view
-			this.app.emit("transition", {
+			this.app.emit("app-transition", {
 				viewId: state.target,
 				opts: lang.mixin({reverse: true}, evt.detail, {"params": state.params})
 			});

--- a/controllers/HistoryHash.js
+++ b/controllers/HistoryHash.js
@@ -3,7 +3,7 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/topic", "dojo/on", "../Co
 	// module:
 	//		dojox/app/controllers/HistoryHash
 	// summary:
-	//		Bind "domNode" event on dojox/app application instance,
+	//		Bind "app-domNode" event on dojox/app application instance,
 	//		Bind "startTransition" event on dojox/app application domNode,
 	//		Bind "/dojo/hashchange" event on window object.
 	//		Maintain history by history hash.
@@ -12,14 +12,14 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/topic", "dojo/on", "../Co
 
 		constructor: function(app){
 			// summary:
-			//		Bind "domNode" event on dojox/app application instance,
+			//		Bind "app-domNode" event on dojox/app application instance,
 			//		Bind "startTransition" event on dojox/app application domNode,
 			//		subscribe "/dojo/hashchange" event.
 			//
 			// app:
 			//		dojox/app application instance.
 			this.events = {
-				"domNode": this.onDomNodeChange
+				"app-domNode": this.onDomNodeChange
 			};
 			if(this.app.domNode){
 				this.onDomNodeChange({oldNode: null, newNode: this.app.domNode});
@@ -176,7 +176,7 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/topic", "dojo/on", "../Co
 				this._addHistory(currentHash);
 				if (!this._startTransitionEvent) {
 					// transition to the target view
-					this.app.emit("transition", {
+					this.app.emit("app-transition", {
 						viewId: hash.getTarget(currentHash),
 						opts: { params: hash.getParams(currentHash) || {} }
 					});
@@ -236,7 +236,7 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/topic", "dojo/on", "../Co
 			topic.publish("/app/history/back", {"viewId": target, "detail": detail});
 
 			// transition to the target view
-			this.app.emit("transition", {
+			this.app.emit("app-transition", {
 				viewId: target,
  				opts: lang.mixin({reverse: true}, detail, {"params": hash.getParams(currentHash)})
 			});
@@ -259,7 +259,7 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/topic", "dojo/on", "../Co
 			topic.publish("/app/history/forward", {"viewId": target, "detail": detail});
 
 			// transition to the target view
-			this.app.emit("transition", {
+			this.app.emit("app-transition", {
 				viewId: target,
  				opts: lang.mixin({reverse: false}, detail, {"params": hash.getParams(currentHash)})
 			});
@@ -281,7 +281,7 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/topic", "dojo/on", "../Co
 			topic.publish("/app/history/go", {"viewId": target, "step": step, "detail": this._historyStack[index]["detail"]});
 
 			// transition to the target view
-			this.app.emit("transition", {
+			this.app.emit("app-transition", {
 				viewId: target,
 				opts: lang.mixin({reverse: (step <= 0)}, this._historyStack[index]["detail"], {"params": hash.getParams(this._current)})
 			});

--- a/controllers/Layout.js
+++ b/controllers/Layout.js
@@ -5,13 +5,13 @@ function(declare, lang, array, win, query, domGeom, domAttr, domStyle, registry,
 	// module:
 	//		dojox/app/controllers/Layout
 	// summary:
-	//		Bind "initLayout" and "layoutView" events on dojox/app application instance.
+	//		Extends LayoutBase which binds "app-initLayout", "app-layoutView" and "app-resize" events on application instance.
 
 	return declare("dojox.app.controllers.Layout", LayoutBase, {
 
 		constructor: function(app, events){
 			// summary:
-			//		bind "initLayout" and "layoutView" events on application instance.
+			//		bind "app-initLayout" and "app-layoutView" events on application instance.
 			//
 			// app:
 			//		dojox/app application instance.
@@ -46,11 +46,11 @@ function(declare, lang, array, win, query, domGeom, domAttr, domStyle, registry,
 
 		initLayout: function(event){
 			// summary:
-			//		Response to dojox/app "initLayout" event.
+			//		Response to dojox/app "app-initLayout" event.
 			//
 			// example:
-			//		Use emit to trigger "initLayout" event, and this function will respond to the event. For example:
-			//		|	this.app.emit("initLayout", view);
+			//		Use emit to trigger "app-initLayout" event, and this function will respond to the event. For example:
+			//		|	this.app.emit("app-initLayout", view);
 			//
 			// event: Object
 			// |		{"view": view, "callback": function(){}};
@@ -117,11 +117,11 @@ function(declare, lang, array, win, query, domGeom, domAttr, domStyle, registry,
 
 		layoutView: function(event){
 			// summary:
-			//		Response to dojox/app "layoutView" event.
+			//		Response to dojox/app "app-layoutView" event.
 			//
 			// example:
-			//		Use emit to trigger "layoutView" event, and this function will response the event. For example:
-			//		|	this.app.emit("layoutView", view);
+			//		Use emit to trigger "app-layoutView" event, and this function will response the event. For example:
+			//		|	this.app.emit("app-layoutView", view);
 			//
 			// event: Object
 			// |		{"parent":parent, "view":view, "removeView": boolean}

--- a/controllers/LayoutBase.js
+++ b/controllers/LayoutBase.js
@@ -4,22 +4,22 @@ function(lang, declare, has, win, config, domAttr, topic, domStyle, constraints,
 	// module:
 	//		dojox/app/controllers/LayoutBase
 	// summary:
-	//		Bind "layout" and "select" events on dojox/app application instance.
+	//		Bind "app-initLayout", "app-layoutView" and "app-resize" events on application instance.
 
 	return declare("dojox.app.controllers.LayoutBase", Controller, {
 
 		constructor: function(app, events){
 			// summary:
-			//		bind "initLayout" and "layoutView" events on application instance.
+			//		bind "app-initLayout", "app-layoutView" and "app-resize" events on application instance.
 			//
 			// app:
 			//		dojox/app application instance.
 			// events:
 			//		{event : handler}
 			this.events = {
-				"initLayout": this.initLayout,
-				"layoutView": this.layoutView,
-				"resize": this.onResize
+				"app-initLayout": this.initLayout,
+				"app-layoutView": this.layoutView,
+				"app-resize": this.onResize
 			};
 			// if we are using dojo mobile & we are hiding address bar we need to be bit smarter and listen to
 			// dojo mobile events instead
@@ -27,7 +27,7 @@ function(lang, declare, has, win, config, domAttr, topic, domStyle, constraints,
 				topic.subscribe("/dojox/mobile/afterResizeAll", lang.hitch(this, this.onResize));
 			}else{
 				// bind to browsers orientationchange event for ios otherwise bind to browsers resize
-				this.bind(win.global, has("ios") ? "orientationchange" : "resize", lang.hitch(this, this.onResize));
+				this.bind(win.global, has("ios") ? "orientationchange" : "app-resize", lang.hitch(this, this.onResize));
 			}
 		},
 
@@ -45,11 +45,11 @@ function(lang, declare, has, win, config, domAttr, topic, domStyle, constraints,
 		
 		initLayout: function(event){
 			// summary:
-			//		Response to dojox/app "initLayout" event.
+			//		Response to dojox/app "app-initLayout" event.
 			//
 			// example:
-			//		Use emit to trigger "initLayout" event, and this function will respond to the event. For example:
-			//		|	this.app.emit("initLayout", view);
+			//		Use emit to trigger "app-initLayout" event, and this function will respond to the event. For example:
+			//		|	this.app.emit("app-initLayout", view);
 			//
 			// event: Object
 			// |		{"view": view, "callback": function(){}};
@@ -84,11 +84,11 @@ function(lang, declare, has, win, config, domAttr, topic, domStyle, constraints,
 
 		layoutView: function(event){
 			// summary:
-			//		Response to dojox/app "layoutView" event.
+			//		Response to dojox/app "app-layoutView" event.
 			//
 			// example:
-			//		Use emit to trigger "layoutView" event, and this function will response the event. For example:
-			//		|	this.app.emit("layoutView", view);
+			//		Use emit to trigger "app-layoutView" event, and this function will response the event. For example:
+			//		|	this.app.emit("app-layoutView", view);
 			//
 			// event: Object
 			// |		{"parent":parent, "view":view, "removeView": boolean}

--- a/controllers/Load.js
+++ b/controllers/Load.js
@@ -3,27 +3,27 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/on", "dojo/Def
 	// module:
 	//		dojox/app/controllers/Load
 	// summary:
-	//		Bind "load" event on dojox/app application instance.
+	//		Bind "app-load" event on dojox/app application instance.
 	//		Load child view and sub children at one time.
 
 	return declare("dojox.app.controllers.Load", Controller, {
 
 		constructor: function(app, events){
 			// summary:
-			//		bind "load" event on application instance.
+			//		bind "app-load" event on application instance.
 			//
 			// app:
 			//		dojox/app application instance.
 			// events:
 			//		{event : handler}
 			this.events = {
-				"init": this.init,
-				"load": this.load
+				"app-init": this.init,
+				"app-load": this.load
 			};
 		},
 
 		init: function(event){
-			// when the load controller received "init", before the lifecycle really starts we create the root view
+			// when the load controller received "app-init", before the lifecycle really starts we create the root view
 			// if any. This used to be done in main.js but must be done in Load to be able to create custom
 			// views from the Load controller.
 			//create and start child. return Deferred
@@ -41,7 +41,7 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/on", "dojo/Def
 			//
 			// example:
 			//		Use trigger() to trigger "loadArray" event, and this function will response the event. For example:
-			//		|	this.trigger("load", {"parent":parent, "viewId":viewId, "viewArray":viewArray, "callback":function(){...}});
+			//		|	this.trigger("app-load", {"parent":parent, "viewId":viewId, "viewArray":viewArray, "callback":function(){...}});
 			//
 			// event: Object
 			//		LoadArray event parameter. It should be like this: {"parent":parent, "viewId":viewId, "viewArray":viewArray, "callback":function(){...}}
@@ -84,11 +84,11 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/on", "dojo/Def
 
 		loadView: function(event){
 			// summary:
-			//		Response to dojox/app "load" event.
+			//		Response to dojox/app "app-load" event.
 			//
 			// example:
-			//		Use trigger() to trigger "load" event, and this function will response the event. For example:
-			//		|	this.trigger("load", {"parent":parent, "viewId":viewId, "callback":function(){...}});
+			//		Use trigger() to trigger "app-load" event, and this function will response the event. For example:
+			//		|	this.trigger("app-load", {"parent":parent, "viewId":viewId, "callback":function(){...}});
 			//
 			// event: Object
 			//		Load event parameter. It should be like this: {"parent":parent, "viewId":viewId, "callback":function(){...}}

--- a/controllers/Transition.js
+++ b/controllers/Transition.js
@@ -6,7 +6,7 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 
 	// module:
 	//		dojox/app/controllers/transition
-	//		Bind "transition" event on dojox/app application instance.
+	//		Bind "app-transition" event on dojox/app application instance.
 	//		Do transition from one view to another view.
 	return declare("dojox.app.controllers.Transition", Controller, {
 
@@ -16,15 +16,15 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 
 		constructor: function(app, events){
 			// summary:
-			//		bind "transition" event on application instance.
+			//		bind "app-transition" event on application instance.
 			//
 			// app:
 			//		dojox/app application instance.
 			// events:
 			//		{event : handler}
 			this.events = {
-				"transition": this.transition,
-				"domNode": this.onDomNodeChange
+				"app-transition": this.transition,
+				"app-domNode": this.onDomNodeChange
 			};
 			require([this.app.transit || "dojox/css3/transit"], function(t){
 				transit = t;
@@ -36,14 +36,14 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 
 		transition: function(event){
 			// summary:
-			//		Response to dojox/app "transition" event.
+			//		Response to dojox/app "app-transition" event.
 			//
 			// example:
-			//		Use emit to trigger "transition" event, and this function will response to the event. For example:
-			//		|	this.app.emit("transition", {"viewId": viewId, "opts": opts});
+			//		Use emit to trigger "app-transition" event, and this function will response to the event. For example:
+			//		|	this.app.emit("app-transition", {"viewId": viewId, "opts": opts});
 			//
 			// event: Object
-			//		"transition" event parameter. It should be like this: {"viewId": viewId, "opts": opts}
+			//		"app-transition" event parameter. It should be like this: {"viewId": viewId, "opts": opts}
 			
 			this.proceeding = (event.opts && event.opts.params && event.opts.params.waitToProceed); // waitToProceed passed when visible is true to delay processing.
 
@@ -132,7 +132,7 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 			//		If transition is in proceeding, add the next transition to waiting queue.
 			//
 			// transitionEvt: Object
-			//		"transition" event parameter. It should be like this: {"viewId":viewId, "opts":opts}
+			//		"app-transition" event parameter. It should be like this: {"viewId":viewId, "opts":opts}
 
 			if(this.proceeding){
 				this.app.log("in app/controllers/Transition proceedTransition push event", transitionEvt);
@@ -155,7 +155,7 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 				transitionEvt.opts = {};
 			}
 			var params = transitionEvt.params;
-			this.app.emit("load", {
+			this.app.emit("app-load", {
 				"viewId": transitionEvt.viewId,
 				"params": params,
 				"callback": lang.hitch(this, function(){
@@ -319,10 +319,10 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 				this.app.log("> in Transition._doTransition calling app.emit layoutView view next");
 				if(!removeView){
 					// if we are removing the view we must delay the layout to _after_ the animation
-					this.app.emit("layoutView", {"parent": parent, "view": next });
+					this.app.emit("app-layoutView", {"parent": parent, "view": next });
 				}
 				if(doResize){  
-					this.app.emit("resize"); // after last layoutView call resize			
+					this.app.emit("app-resize"); // after last layoutView call resize			
 				}
 				
 				var result = true;
@@ -340,7 +340,7 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 				}
 				when(result, lang.hitch(this, function(){
 					if(removeView){
-						this.app.emit("layoutView", {"parent": parent, "view": current, "removeView": true});
+						this.app.emit("app-layoutView", {"parent": parent, "view": current, "removeView": true});
 					}
 
 					// deactivate sub child of current view, then deactivate current view
@@ -381,9 +381,9 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 			next.afterActivate(current, data);
 			// layout current view, or remove it
 			this.app.log("> in Transition._doTransition calling app.triggger layoutView view next name=[",next.name,"], removeView = [",removeView,"], parent.name=[",next.parent.name,"], next==current path");
-			this.app.emit("layoutView", {"parent":parent, "view": next, "removeView": removeView});
+			this.app.emit("app-layoutView", {"parent":parent, "view": next, "removeView": removeView});
 			if(doResize){
-				this.app.emit("resize"); // after last layoutView call resize
+				this.app.emit("app-resize"); // after last layoutView call resize
 			}
 
 			// do sub transition like transition from "tabScene,tab1" to "tabScene,tab2"

--- a/main.js
+++ b/main.js
@@ -168,7 +168,7 @@ define(["require", "dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare",
 		setDomNode: function(domNode){
 			var oldNode = this.domNode;
 			this.domNode = domNode;
-			this.emit("domNode", {
+			this.emit("app-domNode", {
 				oldNode: oldNode,
 				newNode: domNode
 			});
@@ -194,8 +194,8 @@ define(["require", "dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare",
 				this.constraint = "center";
 			}
 			var emitLoad = function(){
-				// emit "load" event and let controller to load view.
-				this.emit("load", {
+				// emit "app-load" event and let controller to load view.
+				this.emit("app-load", {
 					viewId: this.defaultView,
 					params: this._startParams,
 					callback: lang.hitch(this, function (){
@@ -223,7 +223,7 @@ define(["require", "dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare",
 							constraints.setSelectedChild(this, constraint, this.children[this.id + '_' + selectId]);
 						}
 						// transition to startView. If startView==defaultView, that means initial the default view.
-						this.emit("transition", {
+						this.emit("app-transition", {
 							viewId: this._startView,
 							opts: { params: this._startParams }
 						});
@@ -233,8 +233,8 @@ define(["require", "dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare",
 			};
 			when(controllers, lang.hitch(this, function(result){
 				if(this.template){
-					// emit "init" event so that the Load controller can initialize root view
-					this.emit("init", {
+					// emit "app-init" event so that the Load controller can initialize root view
+					this.emit("app-init", {
 						app: this,  // pass the app into the View so it can have easy access to app
 						name: this.name,
 						type: this.type,

--- a/tests/borderLayoutApp/config.json
+++ b/tests/borderLayoutApp/config.json
@@ -4,7 +4,7 @@
 	"description": "A border layout App",
 	"splash": "splash",
 
-	loaderConfig: {
+	"loaderConfig": {
 		"paths": {
 			"layoutApp": "../dojox/app/tests/borderLayoutApp"
 		}
@@ -102,7 +102,6 @@
 		
 	"views": {
 		"view1":{
-			"definition" : "none",
 			"constraint" : "top",
 			"definition" : "layoutApp/views/view1.js",			
 			"template": "layoutApp/templates/view1.html"
@@ -123,7 +122,6 @@
 			"template": "layoutApp/templates/view4.html"
 		},
 		"view5":{
-			"definition" : "none",
 			"constraint" : "center",
 			"definition" : "layoutApp/views/view5.js",
 			"template": "layoutApp/templates/view5.html"

--- a/tests/doh/hasConfigTest/config.json
+++ b/tests/doh/hasConfigTest/config.json
@@ -27,16 +27,16 @@
 	// These configTest... lines are only used for the doh test, this is not typical for a config
 	"has" : {
 		"testTrue" : {
-			"configTestSetTrueInHas": "SetInHasOk",
+			"configTestSetTrueInHas": "SetInHasOk"
 		},
 		"testFalse" : {
-			"configTestNotSetInHas": "FAILED",
+			"configTestNotSetInHas": "FAILED"
 		},
 		"phone,ios,andriod" : {
-			"configTestPhoneIosOrAndroid": "Yes",
+			"configTestPhoneIosOrAndroid": "Yes"
 		},
 		"ios,andriod,tablet" : {
-			"configTestTabletIosOrAndroid": "Yes",
+			"configTestTabletIosOrAndroid": "Yes"
 		},
 		"phone" : {
 			"configTestPhone": "Yes",
@@ -48,12 +48,12 @@
 		},
 		"ie" : {
 			"controllers": [
-				"dojox/app/controllers/HistoryHash",
+				"dojox/app/controllers/HistoryHash"
 			]
 		},
 		"notIE" : {
 			"controllers": [
-				"dojox/app/controllers/History",
+				"dojox/app/controllers/History"
 			]
 		}
 	},	

--- a/tests/mediaQueryLayoutApp/controllers/CssLayout.js
+++ b/tests/mediaQueryLayoutApp/controllers/CssLayout.js
@@ -13,12 +13,12 @@ function(declare, dom, domStyle, domClass, domAttr, domConstruct, LayoutBase, re
 
 		initLayout: function(event){
 			// summary:
-			//		Response to dojox/app "initLayout" event which is setup in LayoutBase.
+			//		Response to dojox/app "app-initLayout" event which is setup in LayoutBase.
 			//		The initLayout event is called once when the View is being created the first time.
 			//
 			// example:
-			//		Use emit to trigger "initLayout" event, and this function will respond to the event. For example:
-			//		|	this.app.emit("initLayout", view);
+			//		Use emit to trigger "app-initLayout" event, and this function will respond to the event. For example:
+			//		|	this.app.emit("app-initLayout", view);
 			//
 			// event: Object
 			// |		{"view": view, "callback": function(){}};

--- a/tests/scrollableTestApp/config.json
+++ b/tests/scrollableTestApp/config.json
@@ -86,12 +86,12 @@
 		},
 		"ie9orLess" : {
 			"controllers": [
-				"dojox/app/controllers/HistoryHash",
+				"dojox/app/controllers/HistoryHash"
 			]
 		},
 		"notie9orLess" : {
 			"controllers": [
-				"dojox/app/controllers/History",
+				"dojox/app/controllers/History"
 			]
 		}
 	},	

--- a/tests/scrollableTestApp/views/Scrollable1.js
+++ b/tests/scrollableTestApp/views/Scrollable1.js
@@ -27,7 +27,7 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	};
 	// show an item detail
 	setDetailsContext = function(index){
-		repeatmodel.set("cursorId", index);
+		repeatmodel.set("cursorIndex", index);		
 	};
 	
 	removeScrollableItem = function(index){

--- a/tests/scrollableTestApp/views/Scrollable2.js
+++ b/tests/scrollableTestApp/views/Scrollable2.js
@@ -23,7 +23,7 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	};
 	// show an item detail
 	setDetailsContext = function(index){
-		repeatmodel.set("cursorId", index);
+		repeatmodel.set("cursorIndex", index);
 	};
 	
 	removeScrollableItem = function(index){

--- a/tests/scrollableTestApp/views/Scrollable3.js
+++ b/tests/scrollableTestApp/views/Scrollable3.js
@@ -23,7 +23,7 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	};
 	// show an item detail
 	setDetailsContext = function(index){
-		repeatmodel.set("cursorId", index);
+		repeatmodel.set("cursorIndex", index);
 	};
 	
 	removeScrollableItem = function(index){

--- a/tests/scrollableTestApp/views/Scrollable4.js
+++ b/tests/scrollableTestApp/views/Scrollable4.js
@@ -23,7 +23,7 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	};
 	// show an item detail
 	setDetailsContext = function(index){
-		repeatmodel.set("cursorId", index);
+		repeatmodel.set("cursorIndex", index);
 	};
 	
 	removeScrollableItem = function(index){

--- a/tests/scrollableTestApp/views/Scrollable5.js
+++ b/tests/scrollableTestApp/views/Scrollable5.js
@@ -23,7 +23,7 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	};
 	// show an item detail
 	setDetailsContext = function(index){
-		repeatmodel.set("cursorId", index);
+		repeatmodel.set("cursorIndex", index);
 	};
 	
 	removeScrollableItem = function(index){

--- a/tests/scrollableTestApp2/config.json
+++ b/tests/scrollableTestApp2/config.json
@@ -82,12 +82,12 @@
 		},
 		"ie9orLess" : {
 			"controllers": [
-				"dojox/app/controllers/HistoryHash",
+				"dojox/app/controllers/HistoryHash"
 			]
 		},
 		"notie9orLess" : {
 			"controllers": [
-				"dojox/app/controllers/History",
+				"dojox/app/controllers/History"
 			]
 		}
 	},	
@@ -120,12 +120,12 @@
 				"definition": "scrollableTestApp/views/configuration/ScrollableListSelection.js",
 				"has" : {
 					"phone" : {
-						"constraint" : "center",
+						"constraint" : "center"
 					},
 					"tablet" : { 
-						"constraint" : "left",
-					},	
-				},
+						"constraint" : "left"
+					}	
+				}
 		},
 		
 		"TestInfo": {

--- a/tests/scrollableTestApp2/views/Scrollable1.js
+++ b/tests/scrollableTestApp2/views/Scrollable1.js
@@ -27,7 +27,7 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	};
 	// show an item detail
 	setDetailsContext = function(index){
-		repeatmodel.set("cursorId", index);
+		repeatmodel.set("cursorIndex", index);
 	};
 	
 	removeScrollableItem = function(index){

--- a/tests/scrollableTestApp2/views/Scrollable2.js
+++ b/tests/scrollableTestApp2/views/Scrollable2.js
@@ -23,7 +23,7 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	};
 	// show an item detail
 	setDetailsContext = function(index){
-		repeatmodel.set("cursorId", index);
+		repeatmodel.set("cursorIndex", index);
 	};
 	
 	removeScrollableItem = function(index){

--- a/tests/scrollableTestApp2/views/Scrollable3.js
+++ b/tests/scrollableTestApp2/views/Scrollable3.js
@@ -23,7 +23,7 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	};
 	// show an item detail
 	setDetailsContext = function(index){
-		repeatmodel.set("cursorId", index);
+		repeatmodel.set("cursorIndex", index);
 	};
 	
 	removeScrollableItem = function(index){

--- a/tests/scrollableTestApp2/views/Scrollable4.js
+++ b/tests/scrollableTestApp2/views/Scrollable4.js
@@ -23,7 +23,7 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	};
 	// show an item detail
 	setDetailsContext = function(index){
-		repeatmodel.set("cursorId", index);
+		repeatmodel.set("cursorIndex", index);
 	};
 	
 	removeScrollableItem = function(index){

--- a/tests/scrollableTestApp2/views/Scrollable5.js
+++ b/tests/scrollableTestApp2/views/Scrollable5.js
@@ -23,7 +23,7 @@ function(dom, domStyle, connect, lang, registry, at, TransitionEvent, Repeat, ge
 	};
 	// show an item detail
 	setDetailsContext = function(index){
-		repeatmodel.set("cursorId", index);
+		repeatmodel.set("cursorIndex", index);
 	};
 	
 	removeScrollableItem = function(index){

--- a/tests/swapViewTestApp/controllers/DivIdBasedLayout.js
+++ b/tests/swapViewTestApp/controllers/DivIdBasedLayout.js
@@ -13,12 +13,12 @@ function(declare, dom, domStyle, domClass, domAttr, domConstruct, LayoutBase, re
 
 		initLayout: function(event){
 			// summary:
-			//		Response to dojox/app "initLayout" event which is setup in LayoutBase.
+			//		Response to dojox/app "app-initLayout" event which is setup in LayoutBase.
 			//		The initLayout event is called once when the View is being created the first time.
 			//
 			// example:
-			//		Use emit to trigger "initLayout" event, and this function will respond to the event. For example:
-			//		|	this.app.emit("initLayout", view);
+			//		Use emit to trigger "app-initLayout" event, and this function will respond to the event. For example:
+			//		|	this.app.emit("app-initLayout", view);
 			//
 			// event: Object
 			// |		{"view": view, "callback": function(){}};


### PR DESCRIPTION
Change the app events being used in our controllers to be prefixed with app-, so for example in ViewBase "initLayout", "layoutView" and "resize" will become "app-initLayout", "app-layoutView" and "app-resize".
