### PR TITLE
Fix problem with resize after the change to the event names.

### DIFF
--- a/controllers/LayoutBase.js
+++ b/controllers/LayoutBase.js
@@ -27,7 +27,7 @@ function(lang, declare, has, win, config, domAttr, topic, domStyle, constraints,
 				topic.subscribe("/dojox/mobile/afterResizeAll", lang.hitch(this, this.onResize));
 			}else{
 				// bind to browsers orientationchange event for ios otherwise bind to browsers resize
-				this.bind(win.global, has("ios") ? "orientationchange" : "app-resize", lang.hitch(this, this.onResize));
+				this.bind(win.global, has("ios") ? "orientationchange" : "resize", lang.hitch(this, this.onResize));
 			}
 		},
 

--- a/controllers/Transition.js
+++ b/controllers/Transition.js
@@ -322,7 +322,7 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 					this.app.emit("app-layoutView", {"parent": parent, "view": next });
 				}
 				if(doResize){  
-					this.app.emit("app-resize"); // after last layoutView call resize			
+					this.app.emit("app-resize"); // after last layoutView fire app-resize			
 				}
 				
 				var result = true;
@@ -383,7 +383,7 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 			this.app.log("> in Transition._doTransition calling app.triggger layoutView view next name=[",next.name,"], removeView = [",removeView,"], parent.name=[",next.parent.name,"], next==current path");
 			this.app.emit("app-layoutView", {"parent":parent, "view": next, "removeView": removeView});
 			if(doResize){
-				this.app.emit("app-resize"); // after last layoutView call resize
+				this.app.emit("app-resize"); // after last layoutView fire app-resize
 			}
 
 			// do sub transition like transition from "tabScene,tab1" to "tabScene,tab2"

--- a/tests/longListTestApp/index.html
+++ b/tests/longListTestApp/index.html
@@ -25,7 +25,7 @@
    					data-dojo-config="mblThemeFiles:['@theme',['dojox/app/tests/longListTestApp','todo']]"></script>
 
 		<script type="text/javascript" src="../../../../dojo/dojo.js" data-dojo-config="parseOnLoad: false,
-				mblHideAddressBar: true,
+				mblHideAddressBar: false,
 				mblAndroidWorkaround: false,
 				mblAlwaysHideAddressBar: true,
 				app: {debugApp: 1},  // set debugApp to log app transtions and view activate/deactivate


### PR DESCRIPTION
Fix problem with resize after the change to the event names, needed to leave the bind for win.global resize if not ios, I should not have changed that one to app-resize.  This broke resize on todoApp becuase it was not using mblHideAddressBar.
