### PR TITLE
Change the config rules for view constraints.

### DIFF
--- a/ViewBase.js
+++ b/ViewBase.js
@@ -14,7 +14,6 @@ define(["require", "dojo/when", "dojo/on", "dojo/dom-attr", "dojo/_base/declare"
 			//		- id: view id
 			//		- name: view name
 			//		- parent: parent view
-			//		- template: view template path 
 			//		- controller: view controller module identifier
 			//		- children: children views
 			this.id = "";
@@ -136,18 +135,12 @@ define(["require", "dojo/when", "dojo/on", "dojo/dom-attr", "dojo/_base/declare"
 			var viewControllerDef = new Deferred();
 			var path;
 
-			if(this.controller && (this.controller === "none")){
+			if(!this.controller){  // no longer using this.controller === "none", if we dont have one it means none.
+				this.app.log("  > in app/ViewBase _loadViewController no controller set for view name=[",this.name,"], parent.name=[",this.parent.name,"]");
 				viewControllerDef.resolve(true);
 				return viewControllerDef;
-			}else if(this.controller){
-				path = this.controller.replace(/(\.js)$/, "");
-			}else if(this.template){
-				path = this.template.replace(/(\.html)$/, "");
 			}else{
-				path = this.id.split("_");
-				path.shift();
-				path = path.join("/");
-				path = "./views/" + path;
+				path = this.controller.replace(/(\.js)$/, "");
 			}
 
 			var requireSignal;

--- a/controllers/Load.js
+++ b/controllers/Load.js
@@ -29,7 +29,6 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/on", "dojo/Def
 			//create and start child. return Deferred
 			when(this.createView(event.parent, null, null, {
 					templateString: event.templateString,
-					template: event.template,
 					controller: event.controller
 			}, null, event.type), function(newView){
 				when(newView.start(), event.callback);
@@ -163,7 +162,7 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/on", "dojo/Def
 			// name: String
 			//		view name.
 			// mixin: String
-			//		additional property to be mixed into the view (templateString, template, controller...)
+			//		additional property to be mixed into the view (templateString, controller...)
 			// params: Object
 			//		params of this view.
 			// type: String

--- a/controllers/Transition.js
+++ b/controllers/Transition.js
@@ -300,13 +300,14 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 				//activate or deactivate views and refresh layout.
 
 				// deactivate sub child of current view, then deactivate current view
-				// TODO: why is "center" hard coded here?
-				var subChild = constraints.getSelectedChild(current, "center");
-				while(subChild){
-					this.app.log("< in Transition._doTransition calling subChild.beforeDeactivate subChild name=[",subChild.name,"], parent.name=[",subChild.parent.name,"], next!==current path");
-					// TODO what to pass to beforeDeactivate here?
-					subChild.beforeDeactivate();
-					subChild = constraints.getSelectedChild(subChild, "center");
+				var selChildren = constraints.getAllSelectedChildren(current);
+				for(var i = 0; i < selChildren.length; i++){					
+					var subChild = selChildren[i];
+					if(subChild && subChild.beforeDeactivate){ 
+						this.app.log("< in Transition._doTransition calling subChild.beforeDeactivate subChild name=[",subChild.name,"], parent.name=[",subChild.parent.name,"], next!==current path");
+						// TODO what to pass to beforeDeactivate here?
+						subChild.beforeDeactivate();
+					}
 				}
 				if(current){
 					this.app.log("< in Transition._doTransition calling current.beforeDeactivate current name=[",current.name,"], parent.name=[",current.parent.name,"], next!==current path");
@@ -344,13 +345,14 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 					}
 
 					// deactivate sub child of current view, then deactivate current view
-					subChild = constraints.getSelectedChild(current, "center");
-					
-					while(subChild){
-						this.app.log("  < in Transition._doTransition calling subChild.afterDeactivate subChild name=[",subChild.name,"], parent.name=[",subChild.parent.name,"], next!==current path");
-						// TODO what  to pass to beforeDeactivate here?
-						subChild.afterDeactivate();
-						subChild = constraints.getSelectedChild(subChild, "center");
+					var selChildren = constraints.getAllSelectedChildren(current);
+					for(var i = 0; i < selChildren.length; i++){					
+						var subChild = selChildren[i];
+						if(subChild && subChild.beforeDeactivate){ 
+							this.app.log("  < in Transition._doTransition calling subChild.afterDeactivate subChild name=[",subChild.name,"], parent.name=[",subChild.parent.name,"], next!==current path");
+							// TODO what  to pass to beforeDeactivate here?
+							subChild.afterDeactivate();
+						}
 					}
 					if(current){
 						this.app.log("  < in Transition._doTransition calling current.afterDeactivate current name=[",current.name,"], parent.name=[",current.parent.name,"], next!==current path");

--- a/main.js
+++ b/main.js
@@ -241,7 +241,6 @@ define(["require", "dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare",
 						parent: this,
 						templateString: this.templateString,
 						controller: this.controller,
-						template: this.template,
 						callback: lang.hitch(this, function(view){
 							this.setDomNode(view.domNode);
 							emitLoad.call(this);

--- a/tests/borderLayoutApp/config.json
+++ b/tests/borderLayoutApp/config.json
@@ -107,17 +107,14 @@
 			"template": "layoutApp/templates/view1.html"
 		},
 		"view2":{
-			"controller" : "none",
 			"constraint" : "top",
 			"template": "layoutApp/templates/view2.html"
 		},
 		"view3":{
-			"controller" : "none",
 			"constraint" : "left",
 			"template": "layoutApp/templates/view3.html"
 		},
 		"view4":{
-			"controller" : "none",
 			"constraint" : "left",
 			"template": "layoutApp/templates/view4.html"
 		},
@@ -127,27 +124,22 @@
 			"template": "layoutApp/templates/view5.html"
 		},
 		"view6":{
-			"controller" : "none",
 			"constraint" : "center",
 			"template": "layoutApp/templates/view6.html"
 		},
 		"view7":{
-			"controller" : "none",
 			"constraint" : "right",
 			"template": "layoutApp/templates/view7.html"
 		},
 		"view8":{
-			"controller" : "none",
 			"constraint" : "right",
 			"template": "layoutApp/templates/view8.html"
 		},
 		"view9":{
-			"controller" : "none",
 			"constraint" : "bottom",
 			"template": "layoutApp/templates/view9.html"
 		},
 		"view10":{
-			"controller" : "none",
 			"constraint" : "bottom",
 			"template": "layoutApp/templates/view10.html"
 		},

--- a/tests/customApp/config.json
+++ b/tests/customApp/config.json
@@ -23,7 +23,6 @@
 
 	"views": {
 		"home": {
-			"controller" : "none",
 			"template": "customApp/home.html",
 			"dependencies":	[
 				"dojox/mobile/RoundRectList",

--- a/tests/doh/error3.json
+++ b/tests/doh/error3.json
@@ -21,7 +21,6 @@
 	"views": {
 
 		"home": { 
-			"controller" : "none",
 			"template": "dojox/app/tests/doh/error3.html"
 		}
 

--- a/tests/doh/error4.json
+++ b/tests/doh/error4.json
@@ -21,7 +21,6 @@
 	"views": {
 
 		"home": { 
-			"controller" : "none",
 			"template": "dojox/app/tests/doh/doesnotexist.html"
 		}
 

--- a/tests/doh/hasConfigTest/config.json
+++ b/tests/doh/hasConfigTest/config.json
@@ -65,7 +65,6 @@
 	"views": {
 
 		"home": { 
-			"controller" : "none",
 			"template": "dojox/app/tests/doh/config.html"
 		}
 

--- a/tests/doh/lifecycleTest/config.json
+++ b/tests/doh/lifecycleTest/config.json
@@ -24,7 +24,6 @@
 	"views": {
 
 		"home": { 
-			"controller" : "none",
 			"template": "dojox/app/tests/doh/config.html"
 		}
 

--- a/tests/doh/simpleModelApp/config.json
+++ b/tests/doh/simpleModelApp/config.json
@@ -103,7 +103,6 @@
 	"views": {
 
 		"home": {
-			"controller" : "none",
 			"dependencies":["dojox/mobile/ListItem","dojox/mobile/RoundRectList","dojox/mobile/RoundRectCategory","dojox/mobile/Heading"],
 			"template": "../app/tests/simpleModelApp/main/main.html"
 		},

--- a/tests/globalizedApp/config.json
+++ b/tests/globalizedApp/config.json
@@ -25,7 +25,6 @@
 
 	"views": {
 		"home": {
-			"controller" : "none",
 			"template": "globalizedApp/home.html",
 			"nls": "globalizedApp/nls/home",
 			"dependencies":	[

--- a/tests/layoutApp/config.json
+++ b/tests/layoutApp/config.json
@@ -67,7 +67,6 @@
 	}, 
 
 	"template": "layoutApp/views/navigation.html",
-	"controller" : "none",
 
 	//the name of the view to load when the app is initialized.
 	"defaultView": "simple",

--- a/tests/layoutApp2/config.json
+++ b/tests/layoutApp2/config.json
@@ -68,7 +68,6 @@
 
 // this app uses constraints and multiple files in defaultView instead of an outer template for a table layout
 //	"template": "layoutApp2/views/navigation.html",
-//	"controller" : "none",
 
 	//the name of the view to load when the app is initialized.
 	"defaultView": "navigation+simple",
@@ -81,7 +80,6 @@
 
 	"views": {
 		"navigation":{
-			"controller" : "none",
 			"constraint" : "left",
 			"template": "layoutApp2/views/navigation.html"
 		},

--- a/tests/longListTestApp/config.json
+++ b/tests/longListTestApp/config.json
@@ -86,11 +86,13 @@
 
 			"views": {
 				"ScrollableListSelection": {
+					"controller": "longListTestApp/views/configuration/ScrollableListSelection.js",
 					"template": "longListTestApp/views/configuration/ScrollableListSelection.html"
 				}
 			}
 		},
 		"Footer1": {
+			"controller": "longListTestApp/views/Footer1.js",
 			"template": "longListTestApp/views/Footer1.html",
 			"views": {
 				"Header1": {
@@ -115,9 +117,11 @@
 			}
 		},
 		"LongList2": {
+			"controller": "longListTestApp/views/LongList2.js",
 			"template": "longListTestApp/views/LongList2.html"
 		},
 		"LongList4": {
+			"controller": "longListTestApp/views/LongList4.js",
 			"template": "longListTestApp/views/LongList4.html"
 		}
 	}

--- a/tests/mediaQueryLayoutApp/config.json
+++ b/tests/mediaQueryLayoutApp/config.json
@@ -84,9 +84,10 @@
 	//"defaultTransition": "fade",
 	//"defaultTransition": "flip",     
 
+	"transition": "flip",     
+
 	"views": {
 		"navigation":{
-			"controller" : "none",
 			"constraint" : "left",
 			"template": "mediaQueryLayoutApp/views/navigation.html"
 		},
@@ -101,7 +102,6 @@
 			"template": "mediaQueryLayoutApp/views/centerNavigation.html"
 		},
 		"header":{
-			"controller" : "none",
 			"constraint" : "top",
 			"template": "mediaQueryLayoutApp/views/header.html"
 		},

--- a/tests/modelApp/config.json
+++ b/tests/modelApp/config.json
@@ -73,7 +73,6 @@
 	"views": {
 
 		"home": { 
-			"controller" : "none",
 			"dependencies":["dojox/mobile/ListItem","dojox/mobile/RoundRectList","dojox/mobile/RoundRectCategory","dojox/mobile/Heading"],
 			"template": "./main/main.html"
 		},
@@ -115,6 +114,7 @@
 		},
 
 		"generate": {
+            "controller": "./generate/generate.js",
             "template": "./generate/generate.html",
             "dependencies":["dojox/mobile/TextBox", "dojox/mobile/TextArea", "dojox/mvc/Generate"]
 		}

--- a/tests/multiSceneApp/config.json
+++ b/tests/multiSceneApp/config.json
@@ -35,7 +35,6 @@
 	"stores": {},
 
 	"template": "./application.html",
-	"controller" : "none",
 
 	//models and instantiation parameters for the models. Including 'type' as a property allows
 	//one to overide the class that will be used for the model.  By default it is dojox/mvc/model
@@ -50,7 +49,6 @@
 
 		//simple scene which loads all views and shows the default first
 		"home": { 
-			"controller" : "none",
 			"dependencies":["dojox/mobile/RoundRectList","dojox/mobile/ListItem", "dojox/mobile/EdgeToEdgeCategory"],
 			"template": "./templates/simple/home.html"
 		},
@@ -58,22 +56,18 @@
 		"main":{
 			//all views in the main scene will be bound to the user model
 			"models": [],
-			"controller" : "none",
 			"template": "./simple.html",
 			"defaultView": "main",
 			"defaultTransition": "slide",
 			//the views available to this scene
 			"views": { 
 				"main":{
-					"controller" : "none",
 					"template": "./templates/simple/main.html"
 				},
 				"second":{
-					"controller" : "none",
 					"template": "./templates/simple/second.html"
 				},
 				"third":{
-					"controller" : "none",
 					"template": "./templates/simple/third.html"
 				}
 			},
@@ -83,22 +77,18 @@
 		"tabscene": { 
 			//all views in the second scene will be bound to the user model
 			"models": [],
-			"controller" : "none",
 			"template": "./tabScene.html",
 			"defaultView": "tab1",
 			"defaultTransition": "flip",
 			//the views available to this scene
 			"views": { 
 				"tab1":{
-					"controller" : "none",
 					"template": "./templates/tabs/tab1.html"
 				},
 				"tab2":{
-					"controller" : "none",
 					"template": "./templates/tabs/tab2.html"
 				},
 				"tab3":{
-					"controller" : "none",
 					"template": "./templates/tabs/tab3.html"
 				}
 			},

--- a/tests/scrollableTestApp/config.json
+++ b/tests/scrollableTestApp/config.json
@@ -109,36 +109,37 @@
 		}
 	},	
 
-	//defaultTransition: The default animation type for the view transition.
-	//the defaultTransition is only used if transition is not set in the config and the transition is not set or 
-	//defaulted on the transitionEvent
+	// defaultTransition: The default animation type for the view transition.
+	// the defaultTransition is only used if transition is not set in the config and the transition is not set or 
+	// defaulted on the transitionEvent
 	// These are the possible defaultTransitions, 
 	//"defaultTransition": "slide",
 	//"defaultTransition": "none",
 	//"defaultTransition": "fade",
 	"defaultTransition": "flip",     // Note: flip does not work with a BorderLayout Controller
 
-	//transition: The animation type to use for all view transitions.
+	// transition: The animation type to use for all view transitions.
 	// if a transition is set on a view or parent it will override the transition set on the transitionEvent or the defaultTransition in the config.
 	//"transition": "slide",
 
-	//views: The children views of an application or of a view. Dependencies may be defined on views for
-	//optimization and organization purposes. Models might also be defined on views if they are view-specific
-	//Finally a view item as three additional properties: transition for specific view transitions, template for
-	//defining the view rendering and finally controller to provide an AMD module to be mixed into the view to 
-	//control it. AMD modules identifiers starting with “.” will be resolved relative to the application root. All other
-	//modules identifiers will be resolved according to the Dojo AMD loader rules and in particular with respect
-	//to its configuration provided as part of the loaderConfig attribute. By default if no controller module is
-	//specified for a view it is looked up automatically in ”./views/<viewId>.js”. If you don’t want a controller
-	//module at all you should specify the “none” value.
+	// views: The children views of an application or of a view. Dependencies may be defined on views for
+	// optimization and organization purposes. Models might also be defined on views if they are view-specific
+	// Finally a view item as three additional properties: transition for specific view transitions, template for
+	// defining the view rendering and finally controller to provide an AMD module to be mixed into the view to 
+	// control it. AMD modules identifiers starting with “.” will be resolved relative to the application root. All other
+	// modules identifiers will be resolved according to the Dojo AMD loader rules and in particular with respect
+	// to its configuration provided as part of the loaderConfig attribute. If you do not want a controller
+	// module at all you should not specify one, setting it to none will no longer work.
+
 	"views": {
 		"configuration": {
 			"defaultView": "ScrollableListSelection",
 			"transition": "slide",
-			"controller": "none",
+			//"controller": "none",
 
 			"views": {
 				"ScrollableListSelection": {
+					"controller": "scrollableTestApp/views/configuration/ScrollableListSelection.js",
 					"template": "scrollableTestApp/views/configuration/ScrollableListSelection.html"
 				}
 			}
@@ -147,27 +148,34 @@
 		
 		"TestInfo": {
 			"transition": "none",
+			"controller": "scrollableTestApp/views/TestInfo.js",
 			"template": "scrollableTestApp/views/TestInfo.html"
 		},
 		"Scrollable1": {
 			"transition": "slide",
+			"controller": "scrollableTestApp/views/Scrollable1.js",
 			"template": "scrollableTestApp/views/Scrollable1.html"
 		},
 		"Scrollable1P": {
 			"transition": "flip",
+			"controller": "scrollableTestApp/views/Scrollable1P.js",
 			"template": "scrollableTestApp/views/Scrollable1P.html"
 		},
 		"Scrollable2": {
 			"transition": "fade",
+			"controller": "scrollableTestApp/views/Scrollable2.js",
 			"template": "scrollableTestApp/views/Scrollable2.html"
 		},
 		"Scrollable3": {
+			"controller": "scrollableTestApp/views/Scrollable3.js",
 			"template": "scrollableTestApp/views/Scrollable3.html"
 		},
 		"Scrollable4": {
+			"controller": "scrollableTestApp/views/Scrollable4.js",
 			"template": "scrollableTestApp/views/Scrollable4.html"
 		},
 		"Scrollable5": {
+			"controller": "scrollableTestApp/views/Scrollable5.js",
 			"template": "scrollableTestApp/views/Scrollable5.html"
 		},
 		"ListItemDomButtons": {
@@ -180,6 +188,7 @@
 		},
 		
 		"repeatDetails": {
+			"controller": "scrollableTestApp/views/repeatDetails.js",
 			"template": "scrollableTestApp/views/repeatDetails.html",
 			"transition": "slide"
 		}

--- a/tests/scrollableTestApp2/config.json
+++ b/tests/scrollableTestApp2/config.json
@@ -10,6 +10,8 @@
 		}
 	},
 
+	// Array of AMD modules identifiers. When defined at the top level dependencies of the dojox/app application. 
+	// When defined at view level, dependencies for the view.
 	"dependencies": [
 		"dojox/mobile/_base",
 		"dojox/mobile/_compat",
@@ -43,13 +45,18 @@
 		"scrollableTestApp/scrollableTestApp"
 	],
 
+	// Array of AMD modules identifiers. Controllers for the application. All the controllers defined here will be 
+	// loaded during application startup to respond to application events and controller the application logic. 
 	"controllers": [
 		"dojox/app/controllers/Load",
 		"dojox/app/controllers/Transition",
 		"dojox/app/controllers/Layout"
 	],	
 
-	//stores we are using
+	// Dojo stores which are used by dojox/app to setup data models. A store item is an object with a
+	// a type and a params property. The type property is the AMD module identifier for the store class to be
+	// instantiated. The content of the params property is passed to the store class constructor to build an 
+	// instance. 
 	"stores": {
 		"repeatStore":{
 			"type": "dojo/data/ItemFileWriteStore",
@@ -59,20 +66,26 @@
 	   }
 	},
 
-	//models and instantiation parameters for the models. Including 'type' as a property allows
-	//one to overide the class that will be used for the model.  By default it is dojox/mvc/model
+	// Models and their instantiation parameters. A model item is an object with three properties: the 
+	// model type, the modelLoader and the params. The modelLoader property defines whether an MVC or a
+	// simple model must be loaded. The type property defines which class must be used for that model using
+	// an AMD module identifier and finally the params property content is passed to the model class 
+	// constructor to build an instance.
 	"models": {
-       "repeatmodels": {
+		"repeatmodels": {
        					"modelLoader": "dojox/app/utils/mvcModel",
-					"type": "dojox/mvc/EditStoreRefListController",
-					"params":{
-						"datastore": {"$ref":"#stores.repeatStore"}
-					}
-        }
+						"type": "dojox/mvc/EditStoreRefListController",
+						"params":{
+							"datastore": {"$ref":"#stores.repeatStore"}
+						}
+		}
 	},
 	
+	// The has section will include the sections for which the has checks are true.  
+	// For the sections with ! it will include the section if the has check is not true.
 	"has" : {
 		"phone" : {
+			//The name(s) of the view(s) to load when the application is initialized.
 			"defaultView": "configuration"
 		},
 		"!phone" : {
@@ -90,22 +103,27 @@
 		}
 	},	
 
-
-	// these are the possible defaultTransitions, 
-	// the defaultTransition is only used if transition is not set in the config and it is not set or defaulted on the transitionEvent
+	// defaultTransition: The default animation type for the view transition.
+	// the defaultTransition is only used if transition is not set in the config and the transition is not set or 
+	// defaulted on the transitionEvent
+	// These are the possible defaultTransitions, 
 	//"defaultTransition": "slide",
 	//"defaultTransition": "none",
 	//"defaultTransition": "fade",
 	"defaultTransition": "flip",     // Note: flip does not work with a BorderLayout Controller
 
-	// these are the possible transitions, 
+	// transition: The animation type to use for all view transitions.
 	// if a transition is set on a view or parent it will override the transition set on the transitionEvent or the defaultTransition in the config.
 	//"transition": "slide",
-	//"transition": "none",
-	//"transition": "fade",
-	//"transition": "flip",
 
-	//views are groups of views and models loaded at once
+	// views: The children views of an application or of a view. Dependencies may be defined on views for
+	// optimization and organization purposes. Models might also be defined on views if they are view-specific
+	// Finally a view item as three additional properties: transition for specific view transitions, template for
+	// defining the view rendering and finally controller to provide an AMD module to be mixed into the view to 
+	// control it. AMD modules identifiers starting with “.” will be resolved relative to the application root. All other
+	// modules identifiers will be resolved according to the Dojo AMD loader rules and in particular with respect
+	// to its configuration provided as part of the loaderConfig attribute. If you do not want a controller
+	// module at all you should not specify one, setting it to none will no longer work.
 	"views": {
 		"navigation": {
 			"template": "scrollableTestApp/views/tablet/ViewScrollableLists.html",
@@ -128,31 +146,38 @@
 		
 		"TestInfo": {
 			"transition": "none",
+			"controller": "scrollableTestApp/views/TestInfo.js",
 			"template": "scrollableTestApp/views/TestInfo.html"
 		},
 		"Scrollable1": {
 			"transition": "slide",
+			"controller": "scrollableTestApp/views/Scrollable1.js",
 			"template": "scrollableTestApp/views/Scrollable1.html"
 		},
 		"Scrollable1P": {
+			"controller": "scrollableTestApp/views/Scrollable1P.js",
 			"template": "scrollableTestApp/views/Scrollable1P.html",
 			"transition": "flip",
 			"constraint" : "center"
 		},
 		"Scrollable2": {
+			"controller": "scrollableTestApp/views/Scrollable2.js",
 			"template": "scrollableTestApp/views/Scrollable2.html",
 			"transition": "fade",
 			"constraint" : "center"
 		},
 		"Scrollable3": {
+			"controller": "scrollableTestApp/views/Scrollable3.js",
 			"template": "scrollableTestApp/views/Scrollable3.html",
 			"constraint" : "center"
 		},
 		"Scrollable4": {
+			"controller": "scrollableTestApp/views/Scrollable4.js",
 			"template": "scrollableTestApp/views/Scrollable4.html",
 			"constraint" : "center"
 		},
 		"Scrollable5": {
+			"controller": "scrollableTestApp/views/Scrollable5.js",
 			"template": "scrollableTestApp/views/Scrollable5.html"
 		},
 		"ListItemDomButtons": {
@@ -167,6 +192,7 @@
 		},
 		
 		"repeatDetails": {
+			"controller": "scrollableTestApp/views/repeatDetails.js",
 			"template": "scrollableTestApp/views/repeatDetails.html",
 			"transition": "slide",
 			"constraint" : "center"

--- a/tests/simpleModelApp/config.json
+++ b/tests/simpleModelApp/config.json
@@ -102,7 +102,6 @@
 	"views": {
 
 		"home": {
-			"controller" : "none",
 			"dependencies":["dojox/mobile/ListItem","dojox/mobile/RoundRectList","dojox/mobile/RoundRectCategory","dojox/mobile/Heading"],
 			"template": "./main/main.html"
 		},
@@ -181,6 +180,7 @@
 					}
 				}
 			},
+			"controller": "./repeat/repeat.js",
 			"template": "./repeat/repeat.html",
 			"dependencies":["dojox/mobile/TextBox","dojox/mvc/Group","dojox/mvc/Repeat","dojox/mvc/Output"]
 		},
@@ -196,16 +196,19 @@
 					}
 				}
 			},
+			"controller": "./repeat/repeat2.js",
 			"template": "./repeat/repeat2.html",
 			"dependencies":["dojox/mobile/TextBox","dojox/mvc/Group","dojox/mvc/Repeat","dojox/mvc/Output"]
 		},
 
 		"repeat3": {
+			"controller": "./repeat/repeat3.js",
 			"template": "./repeat/repeat3.html",
 			"dependencies":["dojox/mobile/TextBox","dojox/mvc/Group","dojox/mvc/Repeat","dojox/mvc/Output"]
 		},
 
 		"generate": {
+			"controller": "./generate/generate.js",
 			"template": "./generate/generate.html",
 			"dependencies":["dojox/mobile/TextBox", "dojox/mobile/TextArea", "dojox/mvc/Generate"]
 		}

--- a/tests/swapViewTestApp/config.json
+++ b/tests/swapViewTestApp/config.json
@@ -110,7 +110,6 @@
 			"template": "swapViewTestApp/views/TestInfo.html"
 		},	
 		"header":{
-			"controller" : "none",
 			"constraint" : "heading1Id",
 			"template": "swapViewTestApp/views/header.html"
 		},

--- a/utils/constraints.js
+++ b/utils/constraints.js
@@ -33,6 +33,33 @@ define(["dojo/_base/array"], function(arr){
 			view.selectedChildren[hash] = child;
 		},
 
+
+		getAllSelectedChildren: function(view, selChildren){
+			// summary:
+			//		get current all selected children for this view and it's selected subviews
+			//
+			// view: View
+			//		the View to get the child from
+			//
+			// selChildren: Array
+			//		the Array of the subChildren found
+			//
+			// returns:
+			//		selChildren array of all of the selected child views
+			//
+			selChildren = selChildren || [];
+			if(view && view.selectedChildren){
+				for(var hash in view.selectedChildren){  
+					if(view.selectedChildren[hash]) {
+						var subChild = view.selectedChildren[hash];
+						selChildren.push(subChild);
+						this.getAllSelectedChildren(subChild, selChildren);
+					}
+				}
+			}
+			return selChildren;
+		},
+
 		register: function(constraint){
 			// if the constraint has already been registered we don't care about it...
 			var type = typeof(constraint);


### PR DESCRIPTION
We are changing the way the config is done for the view, it had been required to set "controller": "none" if you did not want a controller, and it would default to try to find the controller if you did not specify one, now if you do not want a controller you will not set it, and you will have to set it if you have a controller for the view.  I have also updated the tests.
Another change was made to deactivate selectedChildren, removing the hard coded "center" constraint in the Transition controller.
