### PR TITLE
A new test app has 3 columns media query test.

### DIFF
--- a/controllers/Transition.js
+++ b/controllers/Transition.js
@@ -152,7 +152,7 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 			if(!transitionEvt.opts){
 				transitionEvt.opts = {};
 			}
-			var params = transitionEvt.params;
+			var params = transitionEvt.params || transitionEvt.opts.params;
 			this.app.emit("app-load", {
 				"viewId": transitionEvt.viewId,
 				"params": params,
@@ -335,9 +335,11 @@ define(["require", "dojo/_base/lang", "dojo/_base/declare", "dojo/has", "dojo/on
 						// if transition is set for the view (or parent) in the config use it, otherwise use it from the event or defaultTransition from the config
 						transition: this._getTransition(parent, transitionTo, mergedOpts)
 					}); 
+					this.app.log("    > in Transition._doTransition calling transit for next ="+next.name);
 					result = transit(current && current.domNode, next && next.domNode, mergedOpts);
 				}
 				when(result, lang.hitch(this, function(){
+					this.app.log("    < in Transition._doTransition back from transit for next ="+next.name);
 					if(removeView){
 						this.app.emit("app-layoutView", {"parent": parent, "view": current, "removeView": true});
 					}

--- a/tests/mediaQuery3ColumnApp/config.json
+++ b/tests/mediaQuery3ColumnApp/config.json
@@ -1,0 +1,122 @@
+{
+	"id": "MQ3ColApp",
+	"name": "mediaQuery 3 column App",
+	"description": "A mediaQuery 3 column App",
+	"splash": "splash",
+
+	"loaderConfig": {
+		"paths": {
+			"mediaQuery3ColumnApp": "../dojox/app/tests/mediaQuery3ColumnApp"
+		}
+	},
+
+	"dependencies": [
+		"dojox/mobile/_base",
+		"dojox/mobile/compat",
+		"dojox/mobile/TabBar",
+		"dojox/mobile/RoundRect",
+		"dojox/mobile/TabBarButton",
+		"dojox/mobile/Button",
+		"dojox/mobile/RoundRect",
+		"dojox/mobile/RoundRectList",
+		"dojox/mobile/EdgeToEdgeList",
+		"dojox/mobile/Heading",
+		"dojox/mobile/ScrollableView",
+		"dojo/store/Memory",
+		"dojox/mobile/View",
+		"dojox/app/widgets/Container"
+	],
+
+	"modules": [],
+	
+	"controllers": [
+		"dojox/app/controllers/Load",
+		"dojox/app/controllers/Transition",
+		"dojox/app/tests/mediaQuery3ColumnApp/controllers/CssLayout",
+		"dojox/app/tests/mediaQuery3ColumnApp/controllers/NavigationController"
+	],
+
+	// The has section will include the sections for which the has checks are true.  
+	// For the sections with ! it will include the section if the has check is not true.
+	"has" : {
+		"ie9orLess" : {
+			"controllers": [
+				"dojox/app/controllers/HistoryHash"
+			]
+		},
+		"!ie9orLess" : {
+			"controllers": [
+				"dojox/app/controllers/History"
+			]
+		},
+		"isInitiallySmall" : {
+			//the name of the view to load when the app is initialized.
+			"defaultView": "navLeft+navCenter+lastRight",
+		},
+		"!isInitiallySmall" : {
+			//the name of the view to load when the app is initialized.
+			"defaultView": "navLeft+mainCenter+lastRight",
+		}
+	},	
+
+
+	// these are the possilbe defaultTransitions
+	"defaultTransition": "slide",
+	//"defaultTransition": "none",
+	//"defaultTransition": "fade",
+	//"defaultTransition": "flip",     
+
+	"transition": "flip",  //fade may have a problem     
+
+	"views": {
+		"navLeft":{
+			"constraint" : "left",
+			"controller": "mediaQuery3ColumnApp/views/nav/navigation.js",
+			"template": "mediaQuery3ColumnApp/views/nav/navigation.html"
+		},
+		"navCenter":{
+			"constraint" : "center",
+			"controller": "mediaQuery3ColumnApp/views/nav/navigation.js",
+			"template": "mediaQuery3ColumnApp/views/nav/navigation.html"
+		},
+		"mainCenter":{
+			"constraint" : "center",
+			"controller": "mediaQuery3ColumnApp/views/main/main.js",
+			"template": "mediaQuery3ColumnApp/views/main/main.html"
+		},
+		"mainCenter2":{
+			"constraint" : "center",
+			"controller": "mediaQuery3ColumnApp/views/main/main.js",
+			"template": "mediaQuery3ColumnApp/views/main/main.html"
+		},
+		"mainCenter3":{
+			"constraint" : "center",
+			"controller": "mediaQuery3ColumnApp/views/main/main.js",
+			"template": "mediaQuery3ColumnApp/views/main/main.html"
+		},
+		"mainLeft":{
+			"constraint" : "left",
+			"controller": "mediaQuery3ColumnApp/views/main/main.js",
+			"template": "mediaQuery3ColumnApp/views/main/main.html"
+		},
+		"lastRight":{
+			"constraint" : "right",
+			"controller": "mediaQuery3ColumnApp/views/last/last.js",
+			"template": "mediaQuery3ColumnApp/views/last/last.html"
+		},
+		"lastCenter":{
+			"constraint" : "center",
+			"controller" : "mediaQuery3ColumnApp/views/last/last.js",
+			"template": "mediaQuery3ColumnApp/views/last/last.html"
+		},
+		"TestInfo": {
+			"constraint" : "center",
+			"controller" : "mediaQuery3ColumnApp/views/main/TestInfo.js",
+			"template": "mediaQuery3ColumnApp/views/main/TestInfo.html"
+		},	
+		"header":{
+			"constraint" : "top",
+			"template": "mediaQuery3ColumnApp/views/header.html"
+		},
+	}	
+}

--- a/tests/mediaQuery3ColumnApp/controllers/CssLayout.js
+++ b/tests/mediaQuery3ColumnApp/controllers/CssLayout.js
@@ -1,0 +1,61 @@
+define(["dojo/_base/declare", "dojo/dom", "dojo/dom-style",
+		"dojo/dom-class", "dojo/dom-attr", "dojo/dom-construct", 
+		"dojox/app/controllers/LayoutBase", "dijit/registry"],
+function(declare, dom, domStyle, domClass, domAttr, domConstruct, LayoutBase, registry){
+	// module:
+	//		dojox/app/tests/mediaQuery3ColumnApp/controllers/CssLayout
+	// summary:
+	//		Will layout an application with a BorderContainer.  
+	//		Each view to be shown in a region of the BorderContainer will be wrapped in a StackContainer and a ContentPane.
+	//		
+
+	return declare("dojox/app/tests/mediaQuery3ColumnApp/controllers/CssLayout", LayoutBase, {
+
+		constructor: function(app, events){
+			// summary:
+			//		bind "app-initLayout" and "app-layoutView" events on application instance.
+			//
+			// app:
+			//		dojox/app application instance.
+			// events:
+			//		{event : handler}
+		},
+
+		initLayout: function(event){
+			// summary:
+			//		Response to dojox/app "app-initLayout" event which is setup in LayoutBase.
+			//		The initLayout event is called once when the View is being created the first time.
+			//
+			// example:
+			//		Use emit to trigger "app-initLayout" event, and this function will respond to the event. For example:
+			//		|	this.app.emit("app-initLayout", view);
+			//
+			// event: Object
+			// |		{"view": view, "callback": function(){}};
+			this.app.log("in app/controllers/CssLayout.initLayout event.view.name=[",event.view.name,"] event.view.parent.name=[",event.view.parent.name,"]");
+
+
+			this.app.log("in app/controllers/CssLayout.initLayout event.view.constraint=",event.view.constraint);
+			var constraint = event.view.constraint;  // constraint holds the region for this view, center, top etc.
+			
+			event.view.parent.domNode.appendChild(event.view.domNode);
+			domClass.add(event.view.domNode, constraint);  // set the class to the constraint
+
+			this.inherited(arguments);
+		},
+
+		onResize: function(){
+			// do nothing on resize
+		},
+
+		hideView: function(view){
+			domStyle.set(view.domNode, "display", "none !important");
+			//domClass.add(view.domNode, "hide");
+		},
+
+		showView: function(view){
+			domStyle.set(view.domNode, "display", "block");
+			//domClass.remove(view.domNode, "hide");			
+		}
+	});
+});

--- a/tests/mediaQuery3ColumnApp/controllers/NavigationController.js
+++ b/tests/mediaQuery3ColumnApp/controllers/NavigationController.js
@@ -1,0 +1,217 @@
+define(["dojo/_base/lang","dojo/_base/declare", "dojo/dom", "dojo/dom-style", "dojo/sniff", "dojo/_base/window", "dojo/_base/config",
+		"dojo/dom-class", "dojo/dom-attr", "dojo/dom-construct", "dojox/app/Controller", "dijit/registry", "dojox/mobile/TransitionEvent"],
+function(lang, declare, dom, domStyle, has, win, config, domClass, domAttr, domConstruct, Controller, registry, TransitionEvent){
+	// module:
+	//		dojox/app/tests/mediaQuery3ColumnApp/controllers/NavigationController
+	// summary:
+	//		Used to handle Navigation for the application 
+	//		
+
+	return declare("dojox/app/tests/mediaQuery3ColumnApp/controllers/NavigationController", Controller, {
+
+		constructor: function(app, events){
+			this.app = app;
+			// large > 860 medium <= 860  small <= 560 
+			this.small = 560;
+			this.medium = 860;
+	
+			this.lastTransition = "";
+			this.lastParams = "";
+			this.lastEvent = null;
+			this.lastSize = "";
+			
+			this.events = {
+				"MQ3ColApp/TestOption1": this.TestOption1,
+				"MQ3ColApp/MainOption1": this.MainOption1,
+				"MQ3ColApp/MainOption2": this.MainOption2,
+				"MQ3ColApp/MainOption3": this.MainOption3,
+				"MQ3ColApp/LastOption1": this.LastOption1,
+				"MQ3ColApp/LastOption2": this.LastOption2,
+				"MQ3ColApp/LastOption3": this.LastOption3,
+				"MQ3ColApp/BackFromMain": this.BackFromMain,
+				"MQ3ColApp/BackFromTest": this.BackFromTest,
+				"MQ3ColApp/BackFromLast": this.BackFromLast
+			};
+			
+			// if we are using dojo mobile & we are hiding address bar we need to be bit smarter and listen to
+			// dojo mobile events instead
+			if(config.mblHideAddressBar){
+				topic.subscribe("/dojox/mobile/afterResizeAll", lang.hitch(this, this.onResize));
+			}else{
+				// bind to browsers orientationchange event for ios otherwise bind to browsers resize
+				this.bind(win.global, has("ios") ? "orientationchange" : "resize", lang.hitch(this, this.onResize));
+			}
+		},
+		
+		TestOption1: function(e){	
+			this.doTransition(e, "navLeft","TestInfo","lastRight", null, null);		
+		},
+		MainOption1: function(e){	
+			console.log("in NavigationController MainOption1 called.");
+			this.doTransition(e, "navLeft","mainCenter","lastRight", {'mainSel':"MainOption1"}, false);		
+		},
+		MainOption2: function(e){
+			console.log("in NavigationController MainOption2 called.");
+			this.doTransition(e, "navLeft","mainCenter2","lastRight", {'mainSel':"MainOption2"}, false);		
+		},
+		MainOption3: function(e){			
+			console.log("in NavigationController MainOption3 called.");
+			this.doTransition(e, "navLeft","mainCenter3","lastRight", {'mainSel':"MainOption3"}, false);		
+		},
+		LastOption1: function(e){	
+			var params = lang.mixin(this.lastParams,{'lastSel':"LastOption1"});
+			if(this.isMedium()){
+				console.log("in NavigationController LastOption1 called with isMedium.");			
+				this.doTransition(e, "mainLeft","lastCenter","lastRight", params, false);
+			}else if(this.isSmall()){
+				console.log("in NavigationController LastOption1 called with isSmall.");			
+				this.doTransition(e, "navLeft","lastCenter","lastRight", params, false);
+			}else{
+				console.log("in NavigationController LastOption1 called with isLarge.");			
+				this.doTransition(e, "navLeft","mainCenter","lastRight", params, false);
+			}		
+		},
+		LastOption2: function(e){
+			var params = lang.mixin(this.lastParams,{'lastSel':"LastOption2"});
+			if(this.isMedium()){
+				console.log("in NavigationController LastOption2 called with isMedium.");			
+				this.doTransition(e, "mainLeft","lastCenter","lastRight", params, false);
+			}else if(this.isSmall()){
+				console.log("in NavigationController LastOption2 called with isSmall.");			
+				this.doTransition(e, "navLeft","lastCenter","lastRight", params, false);
+			}else{
+				console.log("in NavigationController LastOption2 called with isLarge.");			
+				this.doTransition(e, "navLeft","mainCenter","lastRight", params, false);
+			}		
+		},
+		LastOption3: function(e){			
+			var params = lang.mixin(this.lastParams,{'lastSel':"LastOption3"});
+			if(this.isMedium()){
+				console.log("in NavigationController LastOption3 called with isMedium.");			
+				this.doTransition(e, "mainLeft","lastCenter","lastRight", params, false);
+			}else if(this.isSmall()){
+				console.log("in NavigationController LastOption3 called with isSmall.");			
+				this.doTransition(e, "navLeft","lastCenter","lastRight", params, false);
+			}else{
+				console.log("in NavigationController LastOption2 called with isLarge.");			
+				this.doTransition(e, "navLeft","mainCenter","lastRight", params, false);
+			}		
+					
+		},
+		
+		// These BackFrom ones need work to really go back in the history.
+		BackFromMain: function(e){
+			if(this.isSmall()){
+				console.log("in NavigationController BackFromMain called with isSmall.");	
+				// not sure about using his.lastParams		
+				this.doTransition(e, "navLeft","navCenter","lastRight", this.lastParams, true);		
+			}else{
+				console.log("in NavigationController BackFromMain called with !isSmall.");			
+				this.doTransition(e, "mainCenter","navLeft","lastRight", this.lastParams, true);						
+			}	
+		},
+		BackFromTest: function(e){
+			if(this.isSmall()){
+				console.log("in NavigationController BackFromTest called with isSmall.");			
+				this.doTransition(e, "navLeft","navCenter","lastRight", this.lastParams, true);		
+			}else{
+				console.log("in NavigationController BackFromTest called with !isSmall.");			
+				this.doTransition(e, "navLeft","mainCenter","lastRight", this.lastParams, true);						
+			}	
+		},
+		BackFromLast: function(e){	
+			console.log("in NavigationController BackFromLast called.");			
+			this.doTransition(e, "navLeft","mainCenter","lastRight", this.lastParams, true);		
+		},
+
+		doTransition: function(e, left, center, right, params, back){
+			this.lastLeft = left;
+			this.lastCenter = center;
+			this.lastRight = right;
+			this.lastParams = params;
+			var views = this.lastTransition = left+"+"+center;
+			if(right !== "-lastRight"){
+				views = this.lastTransition = views+"+"+right;
+			}else{
+				views = this.lastTransition = views+right;				
+			}
+			console.log("in NavigationController views = "+views+"  this.params="+this.params);
+			
+			this.lastParams = params;
+			this.lastEvent = e;
+			var transOpts = {
+				title: views,
+				target: views,
+				url: "#"+views,
+				reverse: back,
+				params:params
+			};
+			new TransitionEvent(e.target,transOpts,e).dispatch();
+		},
+
+	
+		
+		onResize: function(){
+			// this is called on a resize, normally we want to use css to adjust, but a resize or an orientation change
+			// causes us to be showing duplicate views, then we need to update the views being shown.
+			
+			if(this.lastSize == this.getSize()){
+				return;
+			}
+			this.lastSize = this.getSize();
+			
+			// for a large screen we should always be showing "navLeft+mainCenter+lastRight"
+			if(this.isLarge() && this.lastEvent && 
+				(this.lastTransition !== "navLeft+mainCenter+lastRight" && this.lastTransition !== "navLeft+TestInfo+lastRight")){
+				console.log("in NavigationController onResize isLarge calling transition with navLeft+mainCenter+lastRight");
+				this.doTransition(this.lastEvent, "navLeft","mainCenter","lastRight", this.lastParams);
+			}else if(this.isMedium() && this.lastEvent){
+				// for a medium screen we need to check for "navLeft+navCenter+lastRight" and for "navLeft+lastCenter+lastRight"
+				if(this.lastTransition == "navLeft+navCenter+lastRight"){
+					console.log("in NavigationController onResize isMedium and navCenter calling transition with navLeft+mainCenter+lastRight");
+					this.doTransition(this.lastEvent, "navLeft","mainCenter","lastRight", this.lastParams);
+				}else if(this.lastTransition == "navLeft+lastCenter+lastRight"){
+					console.log("in NavigationController onResize isMedium and lastCenter calling transition with mainLeft+LastCenter+lastRight");
+					this.doTransition(this.lastEvent, "mainLeft","lastCenter","lastRight", this.lastParams);
+				}	
+			}
+					
+		},
+
+		getSize: function(){				
+			if(this.isLarge()){
+				return "large";
+			}else if(this.isMedium()){
+				return "medium";
+			}else{
+				return "small";				
+			}
+		},
+		
+		// large > 860 medium <= 860  small <= 560 
+		isLarge: function(){				
+			var width = window.innerWidth || document.documentElement.clientWidth;
+			if(width > this.medium){
+				return true;
+			}
+			return false;
+		},
+
+		isMedium: function(){				
+			var width = window.innerWidth || document.documentElement.clientWidth;
+			if(width <= this.medium && width > this.small){
+				return true;
+			}
+			return false;		
+		},
+
+		isSmall: function(){				
+			var width = window.innerWidth || document.documentElement.clientWidth;
+			if(width <= this.small){
+				return true;
+			}
+			return false;		
+		}
+		
+	});
+});

--- a/tests/mediaQuery3ColumnApp/css/mediaQuery3ColumnApp.css
+++ b/tests/mediaQuery3ColumnApp/css/mediaQuery3ColumnApp.css
@@ -1,0 +1,271 @@
+.hide {
+	display: none !important;
+}
+
+.center {
+	float: left;
+	height: 100%; 
+	width: 59.7%;
+}
+
+.top {
+	float: top;
+}
+
+.hideOnTablet {
+	display: none !important;
+}
+
+.hideOnLarge {
+	display: none !important;
+}
+
+.left {
+	float: left; 
+	width: 20% !important;
+	border-right:1px solid black;
+	background-color: #C5CCD3;
+	z-index: 100;	
+	height: 100%; 
+}
+
+.right {
+	float: right; 
+	width: 20%;
+	border-left:1px solid black;
+	background-color: #C5CCD3;
+	z-index: 100;	
+	height: 100%; 
+}
+
+/* Medium */
+@media screen and (max-width: 860px) {
+
+	.left {
+		float: left; 
+		width:20%;
+	}
+
+	.center {
+		float: left;
+		width: 79.6%; 
+	}
+	.showOnMedium {
+		display: block !important;
+	}
+
+	.hideOnMedium {
+		display: none !important;
+	}
+}
+
+
+/* Small */
+@media screen and (max-width: 560px) {
+
+	.left {
+		float: left; 
+		width:0px;
+	}
+
+	.center {
+		float: left;
+		width: 99.6%; 
+	}
+
+	.showOnSmall {
+		display: block !important;
+	}
+	.hideOnSmall {
+		display: none !important;
+	}
+	.hideOnPhone {
+		display: none !important;
+	}
+}
+
+/*
+@media only screen and (orientation: portrait) {
+
+	.left {
+		float: left; 
+		width:0px;
+	}
+
+	.center {
+		float: left;
+		width: 99.6%; 
+	}
+
+	.hideOnPhone {
+		display: none !important;
+	}
+
+	.hideOnTablet {
+		display: block !important;
+	}
+
+}
+
+@media only screen and (orientation: landscape) and (max-width: 568px) {
+	.center {
+		float: left;
+		width: 80%;
+		height: 100%;
+		
+	}
+
+	.left {
+		float: left; 
+		width:20%;
+		border-right:1px solid black;
+		background-color: #C5CCD3;
+		z-index:100;	
+		height: 100%; 
+	}
+
+}
+*/
+/*@media only screen and (device-width: 480px) and (orientation: landscape) and (resolution: 163dpi) { */
+	/* CSS3 Rules for XX iPhone in Portrait Orientation */
+/*@media only screen and (device-width: 568px) and (orientation: landscape) {
+	.center {
+		float: left;
+		width: 300px;
+		height: 100%;
+		
+	}
+
+	.left {
+		float: left; 
+		width:100px;
+		border-right:1px solid black;
+		background-color: #C5CCD3;
+		z-index:100;	
+		height: 100% 
+	}
+}
+*/
+
+
+
+html,body {
+	width: 100%;
+	height: 100%;
+}
+
+button.baseBtn {
+	-webkit-background-clip: padding-box;
+	-webkit-box-align: center;
+	background-clip: padding-box;
+	border-style: solid;
+	border-width: 1px;
+	color: black;
+	font-family: 'Helvetica Neue', HelveticaNeue, Helvetica-Neue, Helvetica, 'BBAlpha Sans';
+	font-size: 18px;
+	font-weight: bold;
+	vertical-align: middle;
+	margin: 10px;
+	height: 34px;
+	border-bottom-left-radius: 7px;
+	border-bottom-right-radius: 7px;
+	border-top-left-radius: 7px;
+	border-top-right-radius: 7px;
+	width: 240px;
+}
+
+button.whiteBtn{
+	background-image: -webkit-gradient(linear, 0% 0, 0% 100%, from(white), color-stop(0.06, #f2f2f2), to(#b7b7b7));
+	border-color: #979797;
+	border-bottom-color: #727272;
+}
+
+button.whiteBtnSelected{
+	background-image: -webkit-gradient(linear, 0% 0, 0% 100%, from(#ffffff), color-stop(0.06, #bbbbbb), to(#fcfcfc));
+	border-color: #979797;
+	border-bottom-color: #727272;
+}
+
+#header button {
+	position:absolute;
+	margin:0px;
+}
+
+#navButton {
+	width:60px;
+}
+
+#loadDiv {
+	position:absolute;
+	left:0px;
+	top:0px;
+	width:100%;
+	height:100%;
+	z-index:999;
+}
+#loadDiv {
+	display:table;
+	font-size: 20px;
+	text-align:center;
+	background-color:white;
+}
+#loadDiv span {
+	display:table-cell;
+	vertical-align:middle;
+}
+
+body .mblProgContainer {
+	top:45%;
+	height: 45px;
+	width: 140px;
+	margin-left:-70px;
+	background-color: #2A2A28;
+	border-style: solid;
+	border-width: 2px;
+	border-color: #666666;
+	border-radius: 0.4em;
+	-webkit-border-radius: 0.4em;
+	-moz-border-radius: 0.4em;
+}
+
+body .mblProgContainer > div {
+	height: 100%;
+	width: 100%;
+	line-height: 45px;
+	vertical-align: middle;
+	font-size: 20px;
+	color: #c2c2c2;
+}
+
+body .mblProg {
+	left: 3px;
+	top: 3px;
+}
+
+body .mblProgContainer > div::after {
+	padding-left: 42px;
+	content: "Updating...";
+}
+
+#jsContent, #htmlContent {
+	padding-left:2px;
+}
+
+@media screen and (max-width: 600px) {
+	#jsContent, #htmlContent {
+		font-size: 14px;
+	}
+}
+
+.hidden {
+	display:none;
+}
+
+/*
+div .navPane {
+	width:250px;
+	border-right:1px solid black;
+	background-color: #C5CCD3;
+	z-index:100;
+}
+*/

--- a/tests/mediaQuery3ColumnApp/index.html
+++ b/tests/mediaQuery3ColumnApp/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+	<head>
+		<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"/>
+		<meta name="apple-mobile-web-app-capable" content="yes" />
+		<title>Media Query 3 Column App</title>
+		<link type="text/css" href="./css/mediaQuery3ColumnApp.css" rel="stylesheet" />
+		<script type="text/javascript" src="../../../../dojox/mobile/deviceTheme.js"></script>
+		<script type="text/javascript" src="../../../../dojo/dojo.js" data-dojo-config="parseOnLoad: false,
+				mblHideAddressBar: false,
+				mblAndroidWorkaround: false,
+				mblAlwaysHideAddressBar: false,
+				app: {debugApp: 1},  // set debugApp to log app transtions and view activate/deactivate
+				async: 1">
+		</script>
+		<script>
+			require(["./mediaQuery3ColumnApp.js"], function(){
+			});
+		</script>
+	</head>
+	<body>
+	</body>
+</html>

--- a/tests/mediaQuery3ColumnApp/mediaQuery3ColumnApp.js
+++ b/tests/mediaQuery3ColumnApp/mediaQuery3ColumnApp.js
@@ -1,0 +1,38 @@
+require(["dojo/_base/window","dojox/app/main", "dojox/json/ref", "dojo/text!./config.json", "dojo/sniff"],
+	function(win, Application, jsonRef, config, has){
+
+	this.small = 560;
+	this.medium = 860;
+	
+	// large > 860 medium <= 860  small <= 560 
+	this.isLarge = function(){				
+		var width = window.innerWidth || document.documentElement.clientWidth;
+		if(width > this.medium){
+			return true;
+		}
+		return false;
+	};
+
+	this.isMedium = function(){				
+		var width = window.innerWidth || document.documentElement.clientWidth;
+		if(width <= this.medium && width > this.small){
+			return true;
+		}
+		return false;		
+	};
+
+	this.isSmall = function(){				
+		var width = window.innerWidth || document.documentElement.clientWidth;
+		if(width <= this.small){
+			return true;
+		}
+		return false;		
+	};
+
+	
+	var config = jsonRef.fromJson(config);
+	has.add("ie9orLess", has("ie") && (has("ie") <= 9));
+	has.add("isInitiallySmall", this.isSmall());
+	Application(config);
+	
+});

--- a/tests/mediaQuery3ColumnApp/views/header.html
+++ b/tests/mediaQuery3ColumnApp/views/header.html
@@ -1,0 +1,17 @@
+<div>
+	<!-- top -->
+<!--	<h1 data-dojo-type="dojox/mobile/Heading" back="Back" data-dojo-props='label:"Media Query Layout App"' data-app-constraint="top"></h1> -->
+	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Media Query 3 Column App", fixed:"top"'>
+		<span class="mblToolBarButton mblToolBarButtonHasLeftArrow hideOnTablet" tabindex="0" id="headerBackButton" 
+			widgetid="headerBackButton">
+			<span class="mblToolBarButtonArrow mblToolBarButtonLeftArrow mblColorDefault mblColorDefault45"></span>
+			<span class="mblToolBarButtonBody mblColorDefault"><table cellpadding="0" cellspacing="0" border="0" class="mblToolBarButtonText">
+				<tbody><tr>
+					<td class="mblToolBarButtonIcon"></td>
+					<td class="mblToolBarButtonLabel">Back</td>
+				</tr></tbody></table>
+			</span>
+		</span>
+	</h1>
+	
+</div>

--- a/tests/mediaQuery3ColumnApp/views/last/last.html
+++ b/tests/mediaQuery3ColumnApp/views/last/last.html
@@ -1,0 +1,32 @@
+<div data-dojo-attach-point="lastOuterDiv">
+	<div data-dojo-type="dojox/app/widgets/Container" data-dojo-attach-point="lastOuterContainer" data-app-constraint="right">
+
+	<!-- <div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" data-dojo-props="scrollable:true">  -->
+		<div>
+	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Last", fixed:"top"'>
+		<span class="mblToolBarButton mblToolBarButtonHasLeftArrow" tabindex="0" data-dojo-attach-point="lastheaderBackButton"
+			widgetid="headerBackButton">
+			<span class="mblToolBarButtonArrow mblToolBarButtonLeftArrow mblColorDefault mblColorDefault45"></span>
+			<span class="mblToolBarButtonBody mblColorDefault"><table cellpadding="0" cellspacing="0" border="0" class="mblToolBarButtonText">
+				<tbody><tr>
+					<td class="mblToolBarButtonIcon"></td>
+					<td class="mblToolBarButtonLabel">Main</td>
+				</tr></tbody></table>
+			</span>
+		</span>
+	</h1>
+	<h2 data-dojo-attach-point="lastH2" data-dojo-type="dojox/mobile/EdgeToEdgeCategory" data-dojo-props='label:"None selected", fixed:"top"'></h2>		
+			<ul data-dojo-attach-point="lastList" data-dojo-type="dojox/mobile/RoundRectList" data-app-constraint="center">
+				<li data-dojo-type="dojox/mobile/ListItem" data-dojo-attach-event="onClick:lastOption1Clicked" data-dojo-props='clickable:true,noArrow:true'>
+					Option 1
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" data-dojo-attach-event="onClick:lastOption2Clicked" data-dojo-props='clickable:true,noArrow:true'>
+					Option 2
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" data-dojo-attach-event="onClick:lastOption3Clicked" data-dojo-props='clickable:true,noArrow:true'>
+					Option 3
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>

--- a/tests/mediaQuery3ColumnApp/views/last/last.js
+++ b/tests/mediaQuery3ColumnApp/views/last/last.js
@@ -1,0 +1,72 @@
+define(["dojo/_base/lang", "dojo/dom", "dojo/dom-class", "dojo/_base/connect", "dijit/registry", "dojox/mvc/at", "dojox/mobile/TransitionEvent", 
+	"dojo/Stateful", "dojox/mvc/parserExtension", "dojox/mvc/sync"],
+function(lang, dom, domClass, connect, registry, at, TransitionEvent, Stateful, parserExtension, sync){
+	var _connectResults = []; // events connect result
+	var previousView = null;
+
+	return {
+		// view init
+		init: function(){
+			console.log("in init for view with this.name = "+this.name);
+
+			// handle the backButton onclick
+			connectResult = connect.connect(this.lastheaderBackButton, "onclick", lang.hitch(this, function(e){
+				this.app.emit("MQ3ColApp/BackFromLast", e);
+			})); 
+			_connectResults.push(connectResult);
+
+			// This code will setup the view to work in the center or the right depending upon the viewName
+			if(this.name == "lastCenter"){
+				this.lastOuterContainer["data-app-constraint"] = "center";
+				domClass.add(this.lastheaderBackButton, "hideOnMedium hideOnLarge showOnSmall");
+				domClass.add(this.lastOuterContainer, "center");
+			}else{
+				this.lastOuterContainer["data-app-constraint"] = "right";				
+				domClass.add(this.lastheaderBackButton, "showOnSmall hideOnMedium hideOnLarge");
+				domClass.add(this.lastOuterDiv, "navPane hideOnMedium");
+				domClass.add(this.lastOuterContainer, "hideOnMedium right");
+			}
+
+
+		},
+		
+		beforeActivate: function(previousView, data){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			this.previousView = previousView;
+
+			// Set the selection from the params
+			if(this.params["lastSel"]){ 
+				this.lastH2.set("label",this.params["lastSel"]+" selected");
+			}
+		},
+
+		beforeDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+		},
+
+		lastOption1Clicked: function(/*Event*/ e){
+			this.app.emit("MQ3ColApp/LastOption1", e);
+		},
+
+		lastOption2Clicked: function(/*Event*/ e){
+			this.app.emit("MQ3ColApp/LastOption2", e);
+		},
+
+		lastOption3Clicked: function(/*Event*/ e){
+			this.app.emit("MQ3ColApp/LastOption3", e);
+		},
+
+		// view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/mediaQuery3ColumnApp/views/main/TestInfo.html
+++ b/tests/mediaQuery3ColumnApp/views/main/TestInfo.html
@@ -1,0 +1,35 @@
+<div   data-dojo-attach-point="testOuterDiv" class="view mblView">
+
+
+<!--	<div data-dojo-type="dojox/mobile/ScrollableView"> -->
+	<div> 
+	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Main", fixed:"top"'>
+		<span class="mblToolBarButton mblToolBarButtonHasLeftArrow showOnSmall" tabindex="0" data-dojo-attach-point="testheaderBackButton" 
+			widgetid="headerBackButton">
+			<span class="mblToolBarButtonArrow mblToolBarButtonLeftArrow mblColorDefault mblColorDefault45"></span>
+			<span class="mblToolBarButtonBody mblColorDefault"><table cellpadding="0" cellspacing="0" border="0" class="mblToolBarButtonText">
+				<tbody><tr>
+					<td class="mblToolBarButtonIcon"></td>
+					<td class="mblToolBarButtonLabel">Nav</td>
+				</tr></tbody></table>
+			</span>
+		</span>
+	</h1>
+		<h2 data-dojo-type="dojox/mobile/EdgeToEdgeCategory" data-app-constraint="top">Test Info for this test.</h2>
+
+		<div>
+			<div class="field-title">This test app has 3 columns, Left (Nav), Center (Main), Right (Last) which are shown (or not shown) based upon media queries.</div>
+			<br>
+			<div class="field-title">The app responds to 3 screen sizes (Large over 860, Medium less than 860, and Small less than 560).</div>
+			<br>
+			<div class="field-title">The views can be reused for different positions, for example in the config there is a navLeft and a navCenter which both use the same controller and templates.</div>
+			<br>
+			<div class="field-title">For Large all 3 columns are shown (navLeft | mainCenter | lastRight).</div>
+			<div class="field-title">For Medium the right column is hidden and the left and center columns are shown (navLeft | mainCenter) or (mainLeft | lastCenter).</div>
+			<div class="field-title">For Small only the center column is shown, the left and right columns are hidden  (navCenter) or (mainCenter) or (lastCenter).</div>
+			<br>
+			<div class="field-title">There is also code in the custom NavigationController which is notified of orientation changes or resize events which will handle the cases where the same logical view is about to be shown in the left and center (or the center and right).</div>
+			<br>
+		</div>
+	</div>
+</div>

--- a/tests/mediaQuery3ColumnApp/views/main/TestInfo.js
+++ b/tests/mediaQuery3ColumnApp/views/main/TestInfo.js
@@ -1,0 +1,37 @@
+define(["dojo/_base/lang", "dojo/dom-class", "dojo/_base/connect"],
+function(lang, domClass, connect){
+	var _connectResults = []; // events connect result
+	var previousView = null;
+
+	return {
+		// view init
+		init: function(){
+			console.log("in init for view with this.name = "+this.name);
+
+			// handle the backButton onclick
+			connectResult = connect.connect(this.testheaderBackButton, "onclick", lang.hitch(this, function(e){
+				this.app.emit("MQ3ColApp/BackFromTest", e);
+			}));
+			_connectResults.push(connectResult);
+			 
+			// This code will setup the classes for the backButton
+			domClass.add(this.testheaderBackButton, "showOnSmall hideOnMedium hideOnLarge");
+		},
+
+
+		afterDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+		},
+
+		// view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/mediaQuery3ColumnApp/views/main/main.html
+++ b/tests/mediaQuery3ColumnApp/views/main/main.html
@@ -1,0 +1,35 @@
+<div  data-dojo-attach-point="mainOuterDiv">
+	<div data-dojo-type="dojox/app/widgets/Container" data-dojo-attach-point="mainOuterContainer" data-app-constraint="center">
+
+	<!-- <div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" data-dojo-props="scrollable:true">  -->
+		<div>
+<!--	<h1 data-dojo-type="dojox/mobile/Heading" back="Back" data-dojo-props='label:"Main", fixed:"top"'> -->
+
+	<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Main", fixed:"top"'>
+		<span class="mblToolBarButton mblToolBarButtonHasLeftArrow" tabindex="0" data-dojo-attach-point="mainheaderBackButton" 
+			widgetid="headerBackButton">
+			<span class="mblToolBarButtonArrow mblToolBarButtonLeftArrow mblColorDefault mblColorDefault45"></span>
+			<span class="mblToolBarButtonBody mblColorDefault"><table cellpadding="0" cellspacing="0" border="0" class="mblToolBarButtonText">
+				<tbody><tr>
+					<td class="mblToolBarButtonIcon"></td>
+					<td class="mblToolBarButtonLabel">Nav</td>
+				</tr></tbody></table>
+			</span>
+		</span>
+	</h1>
+	
+	<h2 data-dojo-attach-point="mainH2" data-dojo-type="dojox/mobile/EdgeToEdgeCategory" data-dojo-props='label:"None selected", fixed:"top"'></h2>		
+			<ul data-dojo-attach-point="navList" data-dojo-type="dojox/mobile/RoundRectList" data-app-constraint="center">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" data-dojo-attach-event="onClick:lastOption1Clicked">
+					Last Option 1
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" data-dojo-attach-event="onClick:lastOption2Clicked">
+					Last Option 2
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" data-dojo-attach-event="onClick:lastOption3Clicked">
+					Last Option 3
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>

--- a/tests/mediaQuery3ColumnApp/views/main/main.js
+++ b/tests/mediaQuery3ColumnApp/views/main/main.js
@@ -1,0 +1,71 @@
+define(["dojo/_base/lang", "dojo/dom-class", "dojo/_base/connect"],
+function(lang, domClass, connect){
+	var _connectResults = []; // events connect result
+	var previousView = null;
+
+	return {
+		// view init
+		init: function(){
+			console.log("in init for view with this.name = "+this.name);
+
+			// handle the backButton onclick
+			connectResult = connect.connect(this.mainheaderBackButton, "onclick", lang.hitch(this, function(e){
+				this.app.emit("MQ3ColApp/BackFromMain", e);
+			})); 
+			_connectResults.push(connectResult);
+
+			// This code will setup the view to work in the left or center depending upon the view name
+			if(this.name == "mainLeft"){
+				this.mainOuterContainer["data-app-constraint"] = "left";
+				domClass.add(this.mainheaderBackButton, "showOnMedium");
+				domClass.add(this.mainOuterContainer, "left");
+				domClass.add(this.mainOuterDiv, "navPane hideOnSmall");  // for main on left
+			}else{
+				this.mainOuterContainer["data-app-constraint"] = "center";				
+				domClass.add(this.mainheaderBackButton, "showOnSmall hideOnMedium hideOnLarge");
+				domClass.add(this.mainOuterContainer, "center");
+			}
+
+
+		},
+		
+		beforeActivate: function(previousView, data){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			this.previousView = previousView;
+			
+			// Set the selection from the params
+			if(this.params["mainSel"]){ 
+				this.mainH2.set("label",this.params["mainSel"]+" selected");
+			}
+		},
+
+		beforeDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+		},
+
+		lastOption1Clicked: function(/*Event*/ e){
+			this.app.emit("MQ3ColApp/LastOption1", e);
+		},
+
+		lastOption2Clicked: function(/*Event*/ e){
+			this.app.emit("MQ3ColApp/LastOption2", e);
+		},
+
+		lastOption3Clicked: function(/*Event*/ e){
+			this.app.emit("MQ3ColApp/LastOption3", e);
+		},
+
+		// view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});

--- a/tests/mediaQuery3ColumnApp/views/nav/navigation.html
+++ b/tests/mediaQuery3ColumnApp/views/nav/navigation.html
@@ -1,0 +1,35 @@
+<div data-dojo-attach-point="navOuterDiv">
+	<!-- left -->
+	<div data-dojo-type="dojox/app/widgets/Container" data-dojo-attach-point="navOuterContainer">
+
+	<!-- <div data-dojo-type="dojox/app/widgets/Container" data-app-constraint="center" data-dojo-props="scrollable:true">  -->
+		<div>
+			<h1 data-dojo-type="dojox/mobile/Heading" data-dojo-props='label:"Nav", fixed:"top"'>
+				<span class="mblToolBarButton mblToolBarButtonHasLeftArrow" tabindex="0" data-dojo-attach-point="navheaderBackButton" 
+					widgetid="headerBackButton">
+					<span class="mblToolBarButtonArrow mblToolBarButtonLeftArrow mblColorDefault mblColorDefault45"></span>
+					<span class="mblToolBarButtonBody mblColorDefault"><table cellpadding="0" cellspacing="0" border="0" class="mblToolBarButtonText">
+						<tbody><tr>
+							<td class="mblToolBarButtonIcon"></td>
+							<td class="mblToolBarButtonLabel">Back</td>
+						</tr></tbody></table>
+					</span>
+				</span>
+			</h1>
+			<ul data-dojo-attach-point="navList" data-dojo-type="dojox/mobile/RoundRectList" data-app-constraint="center">
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" data-dojo-attach-event="onClick:mainOption1Clicked">
+					Main Option 1
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" data-dojo-attach-event="onClick:mainOption2Clicked">
+					Main Option 2
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" data-dojo-attach-event="onClick:mainOption3Clicked">
+					Main Option 3
+				</li>
+				<li data-dojo-type="dojox/mobile/ListItem" clickable="true" data-dojo-attach-event="onClick:testOption1Clicked">
+					Test Information
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>

--- a/tests/mediaQuery3ColumnApp/views/nav/navigation.js
+++ b/tests/mediaQuery3ColumnApp/views/nav/navigation.js
@@ -1,0 +1,65 @@
+define(["dojo/dom-class", "dojo/_base/connect"],
+function(domClass, connect){
+	var _connectResults = []; // events connect result
+	var previousView = null;
+
+	return {
+		// view init
+		init: function(){
+			console.log("in init for view with this.name = "+this.name);
+
+			// the back button is never shown for Nav
+			domClass.add(this.navheaderBackButton, "hide");
+
+			// This code will setup the view to work in the left or center depending upon the view name
+			if(this.name == "navLeft"){
+				this.navOuterContainer["data-app-constraint"] = "left";
+				domClass.add(this.navOuterDiv, "hideOnSmall");  // for navigation on the left
+			}else{
+				this.navOuterContainer["data-app-constraint"] = "center";				
+				domClass.add(this.navOuterContainer, "center");
+			}
+
+		},
+		
+		beforeActivate: function(previousView, data){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+			this.previousView = previousView;
+			
+		},
+
+		beforeDeactivate: function(){
+			// summary:
+			//		view life cycle beforeActivate()
+			//
+		},
+
+		testOption1Clicked: function(/*Event*/ e){
+			e.transitionNext = e.target.parentElement.id;
+			this.app.emit("MQ3ColApp/TestOption1", e);
+		},
+
+		mainOption1Clicked: function(/*Event*/ e){
+			this.app.emit("MQ3ColApp/MainOption1", e);
+		},
+
+		mainOption2Clicked: function(/*Event*/ e){
+			this.app.emit("MQ3ColApp/MainOption2", e);
+		},
+
+		mainOption3Clicked: function(/*Event*/ e){
+			this.app.emit("MQ3ColApp/MainOption3", e);
+		},
+
+		// view destroy
+		destroy: function(){
+			var connectResult = _connectResults.pop();
+			while(connectResult){
+				connect.disconnect(connectResult);
+				connectResult = _connectResults.pop();
+			}
+		}
+	}
+});


### PR DESCRIPTION
A new test app has 3 columns, Left (Nav), Center (Main), Right (Last) which are shown (or not shown) based upon media queries. The app responds to 3 screen sizes (Large over 860, Medium less than 860, and Small less than 560). The views can be reused for different positions, for example in the config there is a navLeft and a navCenter which both use the same controller and templates. For Large all 3 columns are shown (navLeft | mainCenter | lastRight).  For Medium the right column is hidden and the left and center columns are shown (navLeft | mainCenter) or (mainLeft | lastCenter). For Small only the center column is shown, the left and right columns are hidden (navCenter) or (mainCenter) or (lastCenter). There is also code in the custom NavigationController which is notified of orientation changes or resize events which will handle the cases where the same logical view is about to be shown in the left and center (or the center and right).
