### PR TITLE
Add a config option borderLayoutNoSplitter to allow app to not use a splitter on the StackContainer. And remove a couple of bad eding commas from tests

### DIFF
--- a/controllers/BorderLayout.js
+++ b/controllers/BorderLayout.js
@@ -43,8 +43,8 @@ function(declare, domAttr, domStyle, LayoutBase, BorderContainer, StackContainer
 					bc.addChild(reg);
 				}else{ // need a contentPane
 					// this is where the region (constraint) is set for the BorderContainer's StackContainer
-					// TODO: may need a way to make doLayout and splitter configurable
-					sc1 = new StackContainer({doLayout: true, splitter:true, region:constraint, id:event.view.parent.id+"-"+constraint});
+					var noSplitter = this.app.borderLayoutNoSplitter || false;
+					sc1 = new StackContainer({doLayout: true, splitter:!noSplitter, region:constraint, id:event.view.parent.id+"-"+constraint});
 					cp1 = new ContentPane({id:event.view.id+"-cp-"+constraint});
 					cp1.addChild(event.view); // should we use addChild or appendChild?
 					sc1.addChild(cp1);

--- a/tests/borderLayoutApp/config.json
+++ b/tests/borderLayoutApp/config.json
@@ -41,6 +41,8 @@
 	//	"dojox/app/controllers/Layout"         // this test can work with either Layout or BorderLayout
 	],
 
+	"borderLayoutNoSplitter": false,  // set true to turn off the splitter on the StackContainer.
+
 	// these are the possible defaultTransitions, 
 	// the defaultTransition is only used if transition is not set in the config and it is not set or defaulted on the transitionEvent
 	//"defaultTransition": "slide",

--- a/tests/scrollableTestApp/views/Scrollable1P.js
+++ b/tests/scrollableTestApp/views/Scrollable1P.js
@@ -95,7 +95,7 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 						setDetailsContext(this.indexAtStartup);}
 				},
 				childBindings: {
-					titleNode: {value: at("rel:", "First")},
+					titleNode: {value: at("rel:", "First")}
 				},
 				templateString: RoundRectWidListTemplate
 			});

--- a/tests/scrollableTestApp2/views/Scrollable1P.js
+++ b/tests/scrollableTestApp2/views/Scrollable1P.js
@@ -95,7 +95,7 @@ function(dom, domStyle, connect, lang, declare, registry, at, TransitionEvent, R
 						setDetailsContext(this.indexAtStartup);}
 				},
 				childBindings: {
-					titleNode: {value: at("rel:", "First")},
+					titleNode: {value: at("rel:", "First")}
 				},
 				templateString: RoundRectWidListTemplate
 			});


### PR DESCRIPTION
Add a config option borderLayoutNoSplitter to allow app to not use a splitter on the StackContainer. And remove a couple of bad eding commas from tests
